### PR TITLE
[V4][1.x] test: support to run the integration tests on a real TPM hardware

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,8 @@ and executed.
 * cmocka unit test framework
 * Microsoft / IBM Software TPM2 simulator version 532 as packaged by IBM:
 https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
+* Alternately, run the test suite on a real TPM hardware, with a safety
+attention described below.
 
 # System User & Group
 As is common security practice we encourage *everyone* to run the `tpm2-abrmd`
@@ -184,6 +186,20 @@ $ ./configure --with-simulatorbin=/path/to/tpm_server
 If the configure script is able to find the executable you provide through this
 option then executing `make check` will cause the integration tests to be built
 and executed.
+
+Once you have a TPM hardware, configure the `./configure` script through the
+`--test-hwtpm` option:
+```
+$ ./configure --test-hwtpm
+```
+
+The integration tests are executed on a real TPM hardware through running
+`make check`. Note that it requires the root privilege to launch tpm2-abrmd
+to access /dev/tpm0.
+***** ATTENTION *****
+If this test suite is executed against a TPM it may cause damage to the TPM (NV
+storage and private key wear out etc).
+You have been warned.
 
 # Compilation
 Compiling the code requires running `make`. You may provide `make` whatever

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,8 +49,7 @@ if !CODE_COVERAGE
 endif # GCOV
 endif #UNIT
 
-if SIMULATOR_BIN
-TESTS_INTEGRATION = \
+tests_integration = \
     test/integration/auth-session-max.int \
     test/integration/auth-session-start-flush.int \
     test/integration/auth-session-start-save.int \
@@ -71,6 +70,13 @@ TESTS_INTEGRATION = \
     test/integration/password-authorization.int \
     test/integration/tpm2-command-flush-no-handle.int \
     test/integration/util-buf-max-upper-bound.int
+
+if SIMULATOR_BIN
+TESTS_INTEGRATION = $(tests_integration)
+endif
+
+if HWTPM
+TESTS_INTEGRATION = $(tests_integration)
 endif
 
 XFAIL_TESTS = \
@@ -79,8 +85,15 @@ XFAIL_TESTS = \
 
 TESTS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TEST_EXTENSIONS = .int
+if HWTPM
+INT_LOG_COMPILER = $(srcdir)/scripts/run-hwtpm-test.sh
+else
 INT_LOG_COMPILER = $(srcdir)/scripts/int-log-compiler.sh
-INT_LOG_FLAGS = --simulator-bin=$(SIMULATOR_BIN) --tabrmd-bin=$(sbin_PROGRAMS)
+endif
+INT_LOG_FLAGS = --tabrmd-bin=$(sbin_PROGRAMS)
+if SIMULATOR_BIN
+INT_LOG_FLAGS += --simulator-bin=$(SIMULATOR_BIN)
+endif
 
 sbin_PROGRAMS   = src/tpm2-abrmd
 check_PROGRAMS  = $(sbin_PROGRAMS) $(TESTS)

--- a/configure.ac
+++ b/configure.ac
@@ -136,9 +136,22 @@ AC_ARG_WITH([simulatorbin],
                    [AC_MSG_RESULT([no])
                     AC_MSG_ERROR([Simulator binary provided does not exist or not executable. Check path: $with_simulatorbin])])],
             [AC_MSG_RESULT([no])
-             AC_MSG_WARN([No simulator binary provided. Integration tests disabled.])
              with_simulatorbin_set=no])
 AM_CONDITIONAL([SIMULATOR_BIN],[test "x$with_simulatorbin_set" = "xyes"])
+#
+# Real TPM hardware
+#
+AC_ARG_ENABLE([test-hwtpm],
+              [AS_HELP_STRING([--enable-test-hwtpm],
+                  [enable the integration test on a real tpm hardware (default is no)])],
+              [enable_hwtpm=$enableval],
+              [enable_hwtpm=no])
+AS_IF([test \( "x$with_simulatorbin_set" = "xyes" \) -a \( "x$enable_hwtpm" = "xyes" \) ],
+      AC_MSG_ERROR([Simulator binary and real tpm hardware cannot be both enabled.]))
+AM_CONDITIONAL([HWTPM], [test "x$enable_hwtpm" != xno])
+
+AS_IF([test \( "x$with_simulatorbin_set" = "xno" \) -a \( "x$enable_hwtpm" = "xno" \) ],
+      AC_MSG_WARN([No simulator binary or tpm hardware provided. Integration tests disabled.]))
 
 # preprocessor / compiler / linker flags
 #   these macros are defined in m4/flags.m4

--- a/scripts/run-hwtpm-test.sh
+++ b/scripts/run-hwtpm-test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#;**********************************************************************;
+# Copyright (c) 2017, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#;**********************************************************************;
+set -u
+set +o nounset
+
+usage_error ()
+{
+    echo "$0: $*" >&2
+    print_usage >&2
+    exit 2
+}
+print_usage ()
+{
+    cat <<END
+Usage:
+    run-hwtpm-test.sh --tabrmd-bin=FILE
+                        TEST-SCRIPT [TEST-SCRIPT-ARGUMENTS]
+The '--tabrmd-bin' option is mandatory.
+END
+}
+TABRMD_BIN=""
+while test $# -gt 0; do
+    case $1 in
+    --help) print_usage; exit $?;;
+    -r|--tabrmd-bin) TABRMD_BIN=$2; shift;;
+    -r=*|--tabrmd-bin=*) TABRMD_BIN="${1#*=}";;
+    --) shift; break;;
+    -*) usage_error "invalid option: '$1'";;
+     *) break;;
+    esac
+    shift
+done
+
+# This function takes a PID as a parameter and determines whether or not the
+# process is currently running. If the daemon is running 0 is returned. Any
+# other value indicates that the daemon isn't running.
+daemon_status ()
+{
+    local pid=$1
+
+    if [ $(kill -0 "${pid}" 2> /dev/null) ]; then
+        echo "failed to detect running daemon with PID: ${pid}";
+        return 1
+    fi
+    return 0
+}
+
+# This is a generic function to start a daemon, setup the environment
+# variables, redirect output to a log file, store the PID of the daemon
+# in a file and disconnect the daemon from the parent shell.
+daemon_start ()
+{
+    local daemon_bin="$1"
+    local daemon_opts="$2"
+    local daemon_log_file="$3"
+    local daemon_pid_file="$4"
+    local daemon_env="$5"
+    local valgrind_bin="$6"
+    local valgrind_flags="$7"
+
+    env ${daemon_env} ${valgrind_bin} ${valgrind_flags} ${daemon_bin} ${daemon_opts} > ${daemon_log_file} 2>&1 &
+    local ret=$?
+    local pid=$!
+    if [ ${ret} -ne 0 ]; then
+        echo "failed to start daemon: \"${daemon_bin}\" with env: \"${daemon_env}\""
+        exit ${ret}
+    fi
+    sleep 1
+    daemon_status "${pid}"
+    if [ $? -ne 0 ]; then
+        echo "daemon died after successfully starting in background, check " \
+             "log file: ${daemon_log_file}"
+        return 1
+    fi
+    echo ${pid} > ${daemon_pid_file}
+    echo "successfully started daemon: ${daemon_bin} with PID: ${pid}"
+    return 0
+}
+# function to start the dbus-daemon
+# This dbus-daemon creates a session message bus used by the
+# communication between tpm2-abrmd and testcase. The dbus info
+# is told to testcase through DBUS_SESSION_BUS_ADDRESS and
+# DBUS_SESSION_BUS_PID.
+dbus_daemon_start ()
+{
+    local dbus_log_file="$1"
+    local dbus_pid_file="$2"
+    local dbus_opts="--session --print-address 3 --nofork --nopidfile"
+    local dbus_addr_file=`mktemp`
+    local dbus_env="DBUS_VERBOSE=1" 
+
+    exec 3<>$dbus_addr_file
+    daemon_start dbus-daemon "${dbus_opts}" "${dbus_log_file}" "${dbus_pid_file}" \
+        "${dbus_env}"
+    local ret=$?
+    if [ $ret -eq 0 ]; then
+        export DBUS_SESSION_BUS_ADDRESS=`cat "${dbus_addr_file}"`
+        export DBUS_SESSION_BUS_PID=`cat "${dbus_pid_file}"`
+    fi
+    rm -f $dbus_addr_file
+    return $ret
+}
+# function to start the tabrmd
+# This is little more than a call to the daemon_start function with special
+# command line options and an environment string.
+tabrmd_start ()
+{
+    local tabrmd_bin=$1
+    local tabrmd_name=$2
+    local tabrmd_log_file=$3
+    local tabrmd_pid_file=$4
+    local tabrmd_env="G_MESSAGES_DEBUG=all"
+    local tabrmd_opts="--tcti=device --session --dbus-name=${tabrmd_name} --fail-on-loaded-trans"
+    
+    daemon_start "${tabrmd_bin}" "${tabrmd_opts}" "${tabrmd_log_file}" \
+        "${tabrmd_pid_file}" "${tabrmd_env}" "${VALGRIND}" "${LOG_FLAGS}"
+}
+# function to stop a running daemon
+# This function takes a single parameter: a file containing the PID of the
+# process to be killed. The PID is extracted and the daemon killed.
+daemon_stop ()
+{
+    local pid_file=$1
+    local pid=0
+    local ret=0
+
+    if [ ! -f ${pid_file} ]; then
+        echo "failed to stop daemon, no pid file: ${pid_file}"
+        return 1
+    fi
+    pid=$(cat ${pid_file})
+    daemon_status "${pid}"
+    if [ $? -ne 0 ]; then
+        echo "failed to detect running daemon with PID: ${pid}";
+        return ${ret}
+    fi
+    kill ${pid}
+    ret=$?
+    if [ ${ret} -eq 0 ]; then
+        wait ${pid}
+        ret=$?
+    else
+        echo "failed to kill daemon process with PID: ${pid}"
+    fi
+    return ${ret}
+}
+
+# Once option processing is done, $@ should be the name of the test executable
+# followed by all of the options passed to the test executable.
+TEST_BIN=$(realpath "$1")
+TEST_DIR=$(dirname "$1")
+TEST_NAME=$(basename "${TEST_BIN}")
+
+# sanity tests
+if [ `id -u` != "0" ]; then
+    echo "need the root privilege to launch tabrmd for the integration test"
+    exit 1
+fi
+if [ ! -x "${TABRMD_BIN}" ]; then
+    echo "no tarbmd binary provided or not executable"
+    exit 1
+fi
+if [ ! -x "${TEST_BIN}" ]; then
+    echo "no test binary provided or not executable"
+    exit 1
+fi
+
+# start an instance of the dbus-daemon for the test, have it use a random port
+DBUS_LOG_FILE=${TEST_BIN}_dbus.log
+DBUS_PID_FILE=${TEST_BIN}_dbus.pid
+echo "Starting dbus-daemon"
+dbus_daemon_start ${DBUS_LOG_FILE} ${DBUS_PID_FILE}
+PID=$(cat ${DBUS_PID_FILE})
+echo "dbus-daemon PID: ${PID}"
+# start an instance of the tpm2-abrmd daemon for the test, use port from above
+TABRMD_LOG_FILE=${TEST_BIN}_tabrmd.log
+TABRMD_PID_FILE=${TEST_BIN}_tabrmd.pid
+TABRMD_NAME=com.intel.tss2.Tabrmd${PID}
+tabrmd_start ${TABRMD_BIN} ${TABRMD_NAME} ${TABRMD_LOG_FILE} ${TABRMD_PID_FILE}
+if [ $? -ne 0 ]; then
+    echo "failed to start tabrmd with name ${TABRMD_NAME}"
+fi
+
+# execute the test script and capture exit code
+env G_MESSAGES_DEBUG=all TABRMD_TEST_BUS_TYPE=session TABRMD_TEST_BUS_NAME="${TABRMD_NAME}" TABRMD_TEST_TCTI_RETRIES=10 $@
+ret_test=$?
+
+# teardown tabrmd
+daemon_stop ${TABRMD_PID_FILE}
+ret_tabrmd=$?
+rm -rf ${TABRMD_PID_FILE}
+
+# teardown dbus-daemon
+daemon_stop ${DBUS_PID_FILE}
+ret_dbus=$?
+rm -rf ${DBUS_PID_FILE}
+
+# handle exit codes
+if [ $ret_test -ne 0 ]; then
+    echo "Execution of $@ failed: $ret_test"
+    exit $ret_test
+fi
+if [ $ret_tabrmd -ne 0 ]; then
+    echo "Execution of tabrmd failed: $ret_tabrmd"
+    exit $ret_tabrmd
+fi
+if [ $ret_dbus -ne 0 ]; then
+    echo "Execution of dbus-daemon failed: $ret_dbus"
+    exit $ret_dbus
+fi
+
+exit 0


### PR DESCRIPTION
Changelog since V3:

- Use session dbus for the communication between src/tpm2-abrmd and testcase.
- Separate the codes about hw tpm test from int-log-compiler.sh.
- Note: --allow-root option is required for the master branch.
- Here is the diff against int-log-compiler.sh for reviewing scripts/run-hwtpm-test.sh.
```
--- scripts/int-log-compiler.sh	2017-12-15 21:17:41.220889983 +0800
+++ scripts/run-hwtpm-test.sh	2017-12-17 13:24:12.786160958 +0800
@@ -38,18 +38,15 @@
 {
     cat <<END
 Usage:
-    int-log-compiler.sh --simulator-bin=FILE --tabrmd-bin=FILE
+    run-hwtpm-test.sh --tabrmd-bin=FILE
                         TEST-SCRIPT [TEST-SCRIPT-ARGUMENTS]
-The '--simulator-bin' and '--tabrmd-bin' options are mandatory.
+The '--tabrmd-bin' option is mandatory.
 END
 }
-SIM_BIN=""
 TABRMD_BIN=""
 while test $# -gt 0; do
     case $1 in
     --help) print_usage; exit $?;;
-    -s|--simulator-bin) SIM_BIN=$2; shift;;
-    -s=*|--simulator-bin=*) SIM_BIN="${1#*=}";;
     -r|--tabrmd-bin) TABRMD_BIN=$2; shift;;
     -r=*|--tabrmd-bin=*) TABRMD_BIN="${1#*=}";;
     --) shift; break;;
@@ -104,25 +101,28 @@
     echo "successfully started daemon: ${daemon_bin} with PID: ${pid}"
     return 0
 }
-# function to start the simulator
-# This also that we have a private place to store the NVChip file. Since we
-# can't tell the simulator what to name this file we must generate a random
-# directory under /tmp, move to this directory, start the simulator, then
-# return to the old pwd.
-simulator_start ()
-{
-    local sim_bin="$1"
-    local sim_port="$2"
-    local sim_log_file="$3"
-    local sim_pid_file="$4"
-    local sim_tmp_dir="$5"
-    # simulator port is a random port between 1024 and 65535
-
-    cd ${sim_tmp_dir}
-    daemon_start "${sim_bin}" "-port ${sim_port}" "${sim_log_file}" \
-        "${sim_pid_file}" ""
+# function to start the dbus-daemon
+# This dbus-daemon creates a session message bus used by the
+# communication between tpm2-abrmd and testcase. The dbus info
+# is told to testcase through DBUS_SESSION_BUS_ADDRESS and
+# DBUS_SESSION_BUS_PID.
+dbus_daemon_start ()
+{
+    local dbus_log_file="$1"
+    local dbus_pid_file="$2"
+    local dbus_opts="--session --print-address 3 --nofork --nopidfile"
+    local dbus_addr_file=`mktemp`
+    local dbus_env="DBUS_VERBOSE=1" 
+
+    exec 3<>$dbus_addr_file
+    daemon_start dbus-daemon "${dbus_opts}" "${dbus_log_file}" "${dbus_pid_file}" \
+        "${dbus_env}"
     local ret=$?
-    cd -
+    if [ $ret -eq 0 ]; then
+        export DBUS_SESSION_BUS_ADDRESS=`cat "${dbus_addr_file}"`
+        export DBUS_SESSION_BUS_PID=`cat "${dbus_pid_file}"`
+    fi
+    rm -f $dbus_addr_file
     return $ret
 }
 # function to start the tabrmd
@@ -131,14 +131,12 @@
 tabrmd_start ()
 {
     local tabrmd_bin=$1
-    local tabrmd_port=$2
-    local tabrmd_name=$3
-    local tabrmd_log_file=$4
-    local tabrmd_pid_file=$5
-
+    local tabrmd_name=$2
+    local tabrmd_log_file=$3
+    local tabrmd_pid_file=$4
     local tabrmd_env="G_MESSAGES_DEBUG=all"
-    local tabrmd_opts="--tcti=socket --tcti-socket-port=${tabrmd_port} --session --dbus-name=${tabrmd_name} --fail-on-loaded-trans"
-
+    local tabrmd_opts="--tcti=device --session --dbus-name=${tabrmd_name} --fail-on-loaded-trans"
+    
     daemon_start "${tabrmd_bin}" "${tabrmd_opts}" "${tabrmd_log_file}" \
         "${tabrmd_pid_file}" "${tabrmd_env}" "${VALGRIND}" "${LOG_FLAGS}"
 }
@@ -179,8 +177,8 @@
 TEST_NAME=$(basename "${TEST_BIN}")
 
 # sanity tests
-if [ ! -x "${SIM_BIN}" ]; then
-    echo "no simulator binary provided or not executable"
+if [ `id -u` != "0" ]; then
+    echo "need the root privilege to launch tabrmd for the integration test"
     exit 1
 fi
 if [ ! -x "${TABRMD_BIN}" ]; then
@@ -192,47 +190,18 @@
     exit 1
 fi
 
-# start an instance of the simulator for the test, have it use a random port
-SIM_LOG_FILE=${TEST_BIN}_simulator.log
-SIM_PID_FILE=${TEST_BIN}_simulator.pid
-SIM_TMP_DIR=$(mktemp --directory --tmpdir=/tmp tpm_server_XXXXXX)
-PORT_MIN=1024
-PORT_MAX=65534
-BACKOFF_FACTOR=2
-BACKOFF=1
-for i in $(seq 10); do
-    SIM_PORT_DATA=$(od -A n -N 2 -t u2 /dev/urandom | awk -v min=${PORT_MIN} -v max=${PORT_MAX} '{print ($1 % (max - min)) + min}')
-    SIM_PORT_CMD=$((${SIM_PORT_DATA}+1))
-    echo "Starting simulator on port ${SIM_PORT_DATA}"
-    simulator_start ${SIM_BIN} ${SIM_PORT_DATA} ${SIM_LOG_FILE} ${SIM_PID_FILE} ${SIM_TMP_DIR}
-    sleep 1 # give daemon time to bind to ports
-    PID=$(cat ${SIM_PID_FILE})
-    echo "simulator PID: ${PID}";
-    netstat -ltpn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_DATA}"
-    ret_data=$?
-    netstat -ltpn 2> /dev/null | grep "${PID}" | grep -q "${SIM_PORT_CMD}"
-    ret_cmd=$?
-    if [ \( $ret_data -eq 0 \) -a \( $ret_cmd -eq 0 \) ]; then
-        echo "Simulator with PID ${PID} bound to port ${SIM_PORT_DATA} and " \
-             "${SIM_PORT_CMD} successfully.";
-        break
-    fi
-    echo "Port conflict? Cleaning up PID: ${PID}"
-    kill "${PID}"
-    BACKOFF=$((${BACKOFF}*${BACKOFF_FACTOR}))
-    echo "Failed to start simulator: port ${SIM_PORT_DATA} or " \
-         "${SIM_PORT_CMD} probably in use. Retrying in ${BACKOFF}."
-    sleep ${BACKOFF}
-    if [ $i -eq 10 ]; then
-        echo "Failed to start simulator after $i tries. Giving up.";
-        exit 1
-    fi
-done
+# start an instance of the dbus-daemon for the test, have it use a random port
+DBUS_LOG_FILE=${TEST_BIN}_dbus.log
+DBUS_PID_FILE=${TEST_BIN}_dbus.pid
+echo "Starting dbus-daemon"
+dbus_daemon_start ${DBUS_LOG_FILE} ${DBUS_PID_FILE}
+PID=$(cat ${DBUS_PID_FILE})
+echo "dbus-daemon PID: ${PID}"
 # start an instance of the tpm2-abrmd daemon for the test, use port from above
 TABRMD_LOG_FILE=${TEST_BIN}_tabrmd.log
 TABRMD_PID_FILE=${TEST_BIN}_tabrmd.pid
-TABRMD_NAME=com.intel.tss2.Tabrmd${SIM_PORT_DATA}
-tabrmd_start ${TABRMD_BIN} ${SIM_PORT_DATA} ${TABRMD_NAME} ${TABRMD_LOG_FILE} ${TABRMD_PID_FILE}
+TABRMD_NAME=com.intel.tss2.Tabrmd${PID}
+tabrmd_start ${TABRMD_BIN} ${TABRMD_NAME} ${TABRMD_LOG_FILE} ${TABRMD_PID_FILE}
 if [ $? -ne 0 ]; then
     echo "failed to start tabrmd with name ${TABRMD_NAME}"
 fi
@@ -241,19 +210,15 @@
 env G_MESSAGES_DEBUG=all TABRMD_TEST_BUS_TYPE=session TABRMD_TEST_BUS_NAME="${TABRMD_NAME}" TABRMD_TEST_TCTI_RETRIES=10 $@
 ret_test=$?
 
-# This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a
-# second after the test finishes the simulator will die too. Bug in the
-# simulator?
-sleep 1
-
 # teardown tabrmd
 daemon_stop ${TABRMD_PID_FILE}
 ret_tabrmd=$?
 rm -rf ${TABRMD_PID_FILE}
 
-# teardown simulator, ignore exit code (it's 143?)
-daemon_stop ${SIM_PID_FILE}
-rm -rf ${SIM_TMP_DIR} ${SIM_PID_FILE}
+# teardown dbus-daemon
+daemon_stop ${DBUS_PID_FILE}
+ret_dbus=$?
+rm -rf ${DBUS_PID_FILE}
 
 # handle exit codes
 if [ $ret_test -ne 0 ]; then
@@ -264,5 +229,9 @@
     echo "Execution of tabrmd failed: $ret_tabrmd"
     exit $ret_tabrmd
 fi
+if [ $ret_dbus -ne 0 ]; then
+    echo "Execution of dbus-daemon failed: $ret_dbus"
+    exit $ret_dbus
+fi
 
 exit 0
```