### PR TITLE
1.x session load across connection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,7 @@ TESTS_INTEGRATION = \
     test/integration/create-keys.int \
     test/integration/get-capability-handles-transient.int \
     test/integration/manage-transient-keys.int \
+    test/integration/session-load-from-open-connection.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-cancel.int \
     test/integration/tcti-connect-multiple.int \
@@ -454,6 +455,11 @@ test_integration_get_capability_handles_transient_int_LDADD   = $(libtest) \
     $(libtcti_tabrmd) $(GLIB_LIBS) $(SAPI_LIBS)
 test_integration_get_capability_handles_transient_int_SOURCES = \
     test/integration/main.c test/integration/get-capability-handles-transient.int.c
+
+test_integration_session_load_from_open_connection_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
+    $(GLIB_LIBS)
+test_integration_session_load_from_open_connection_int_SOURCES = \
+    test/integration/session-load-from-open-connection.int.c
 
 test_integration_start_auth_session_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS)
 test_integration_start_auth_session_int_SOURCES = test/integration/main.c test/integration/start-auth-session.int.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,6 +55,7 @@ TESTS_INTEGRATION = \
     test/integration/create-keys.int \
     test/integration/get-capability-handles-transient.int \
     test/integration/manage-transient-keys.int \
+    test/integration/session-load-from-closed-connection.int \
     test/integration/session-load-from-open-connection.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-cancel.int \
@@ -69,6 +70,7 @@ TESTS_INTEGRATION = \
 endif
 
 XFAIL_TESTS = \
+    test/integration/session-load-from-closed-connection.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-sessions-max.int
 
@@ -460,6 +462,11 @@ test_integration_session_load_from_open_connection_int_LDADD   = $(libtest) $(li
     $(GLIB_LIBS)
 test_integration_session_load_from_open_connection_int_SOURCES = \
     test/integration/session-load-from-open-connection.int.c
+
+test_integration_session_load_from_closed_connection_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
+    $(GLIB_LIBS)
+test_integration_session_load_from_closed_connection_int_SOURCES = \
+    test/integration/session-load-from-closed-connection.int.c
 
 test_integration_start_auth_session_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS)
 test_integration_start_auth_session_int_SOURCES = test/integration/main.c test/integration/start-auth-session.int.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,6 @@ TESTS_INTEGRATION = \
 endif
 
 XFAIL_TESTS = \
-    test/integration/session-save-across-connections-lru.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-sessions-max.int
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,7 @@ TESTS_INTEGRATION = \
     test/integration/get-capability-handles-transient.int \
     test/integration/manage-transient-keys.int \
     test/integration/session-load-from-closed-connection.int \
+    test/integration/session-load-from-closed-connections-lru.int \
     test/integration/session-load-from-open-connection.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-cancel.int \
@@ -71,6 +72,7 @@ endif
 
 XFAIL_TESTS = \
     test/integration/session-load-from-closed-connection.int \
+    test/integration/session-save-across-connections-lru.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-sessions-max.int
 
@@ -467,6 +469,11 @@ test_integration_session_load_from_closed_connection_int_LDADD   = $(libtest) $(
     $(GLIB_LIBS)
 test_integration_session_load_from_closed_connection_int_SOURCES = \
     test/integration/session-load-from-closed-connection.int.c
+
+test_integration_session_load_from_closed_connections_lru_int_LDADD   = $(libtest) $(libtcti_tabrmd) \
+    $(GLIB_LIBS)
+test_integration_session_load_from_closed_connections_lru_int_SOURCES = \
+    test/integration/session-load-from-closed-connections-lru.int.c
 
 test_integration_start_auth_session_int_LDADD   = $(libtest) $(libtcti_tabrmd) $(GLIB_LIBS)
 test_integration_start_auth_session_int_SOURCES = test/integration/main.c test/integration/start-auth-session.int.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,6 @@ TESTS_INTEGRATION = \
 endif
 
 XFAIL_TESTS = \
-    test/integration/session-load-from-closed-connection.int \
     test/integration/session-save-across-connections-lru.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-sessions-max.int

--- a/src/resource-manager.h
+++ b/src/resource-manager.h
@@ -51,6 +51,7 @@ typedef struct _ResourceManager {
     MessageQueue     *in_queue;
     Sink             *sink;
     SessionList      *session_list;
+    GQueue           *abandoned_session_queue;
 } ResourceManager;
 
 #define TYPE_RESOURCE_MANAGER              (resource_manager_get_type ())

--- a/src/session-entry-state-enum.c
+++ b/src/session-entry-state-enum.c
@@ -32,6 +32,8 @@ session_entry_state_to_str (SessionEntryStateEnum state)
     switch (state) {
     case SESSION_ENTRY_SAVED_CLIENT:
         return "saved-client";
+    case SESSION_ENTRY_SAVED_CLIENT_CLOSED:
+        return "saved_client-closed";
     case SESSION_ENTRY_SAVED_RM:
         return "saved-rm";
     default:
@@ -55,6 +57,12 @@ session_entry_state_enum_get_type (void)
                 SESSION_ENTRY_SAVED_CLIENT,
                 "SessionEntry for context saved by the client",
                 "SavedClient"
+            },
+            {
+                SESSION_ENTRY_SAVED_CLIENT_CLOSED,
+                "SesssionEntry for context saved by client over a connection "
+                "that has been closed",
+                "SavedClientClosed",
             },
             { 0, NULL, NULL }
         };

--- a/src/session-entry-state-enum.h
+++ b/src/session-entry-state-enum.h
@@ -34,6 +34,7 @@ G_BEGIN_DECLS
 typedef enum SESSION_ENTRY_STATE {
     SESSION_ENTRY_SAVED_RM,
     SESSION_ENTRY_SAVED_CLIENT,
+    SESSION_ENTRY_SAVED_CLIENT_CLOSED,
 } SessionEntryStateEnum;
 
 #define TYPE_SESSION_ENTRY_STATE_ENUM   (session_entry_state_enum_get_type ())

--- a/src/session-entry.c
+++ b/src/session-entry.c
@@ -211,11 +211,31 @@ session_entry_get_state (SessionEntry *entry)
 {
     return entry->state;
 }
+/*
+ * This function allows the caller to set the state of the SessionEntry. It
+ * also ensures that if the SessionEntry is put into the 'SAVED_CLIENT_CLOSED'
+ * state that the connection field is clear / NULL.
+ */
 void
 session_entry_set_state (SessionEntry *entry,
                          SessionEntryStateEnum state)
 {
+    if (state == SESSION_ENTRY_SAVED_CLIENT_CLOSED) {
+        g_clear_object (&entry->connection);
+    }
     entry->state = state;
+}
+/*
+ * When the connection is set the previous connection, if there was one, must
+ * have its reference count decremented and the internal pointer NULLed.
+ */
+void
+session_entry_set_connection (SessionEntry *entry,
+                              Connection   *connection)
+{
+    g_object_ref (connection);
+    g_clear_object (&entry->connection);
+    entry->connection = connection;
 }
 void
 session_entry_prettyprint (SessionEntry *entry)

--- a/src/session-entry.h
+++ b/src/session-entry.h
@@ -61,6 +61,8 @@ Connection*      session_entry_get_connection  (SessionEntry      *entry);
 TPM_HANDLE       session_entry_get_handle      (SessionEntry      *entry);
 TPMS_CONTEXT*    session_entry_get_context     (SessionEntry      *entry);
 SessionEntryStateEnum session_entry_get_state  (SessionEntry      *entry);
+void             session_entry_set_connection  (SessionEntry      *entry,
+                                                Connection        *connection);
 void             session_entry_set_state       (SessionEntry      *entry,
                                                 SessionEntryStateEnum state);
 void             session_entry_prettyprint     (SessionEntry      *entry);

--- a/src/session-list.h
+++ b/src/session-list.h
@@ -48,7 +48,7 @@ typedef struct _SessionList {
     GObject             parent_instance;
     pthread_mutex_t     mutex;
     guint               max_per_connection;
-    GSList             *session_entry_slist;
+    GList              *session_entry_list;
 } SessionList;
 
 #define TYPE_SESSION_LIST              (session_list_get_type   ())

--- a/test/integration/session-load-from-closed-connection.int.c
+++ b/test/integration/session-load-from-closed-connection.int.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <inttypes.h>
+#include <glib.h>
+#include <stdio.h>
+
+#include <sapi/tpm20.h>
+
+#include "common.h"
+#include "test-options.h"
+#include "context-util.h"
+
+#define PRIxHANDLE "08" PRIx32
+
+/*
+ * This test exercises the session tracking logic, specifically it creates an
+ * auth session over one connection to the RM, saves it, then closes down said
+ * connection. A new connection is then created and the same session is loaded
+ * from this new connection.
+ * In this way we're testing the RMs ability to have a saved session live on
+ * beyond the session that created it.
+ */
+int
+main (int argc,
+      char *argv[])
+{
+    TSS2_RC rc;
+    TSS2_SYS_CONTEXT *sapi_context;
+    TPMI_SH_AUTH_SESSION  session_handle = 0, session_handle_load = 0;
+    TPMS_CONTEXT          context = { 0, };
+    test_opts_t opts = {
+        .tcti_type      = TCTI_DEFAULT,
+        .device_file    = DEVICE_PATH_DEFAULT,
+        .socket_address = HOSTNAME_DEFAULT,
+        .socket_port    = PORT_DEFAULT,
+        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
+        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
+        .tcti_retries    = TCTI_RETRIES_DEFAULT,
+    };
+
+    get_test_opts_from_env (&opts);
+    if (sanity_check_test_opts (&opts) != 0)
+        exit (1);
+    g_info ("Creating first SAPI context");
+    sapi_context = sapi_init_from_opts (&opts);
+    if (sapi_context == NULL) {
+        g_error ("Failed to create SAPI context.");
+    }
+    g_info ("Got SAPI context: 0x%" PRIxPTR, (uintptr_t)sapi_context);
+    /* create an auth session */
+    g_info ("Starting unbound, unsaulted auth session");
+    rc = start_auth_session (sapi_context, &session_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxHANDLE, rc);
+    }
+    g_info ("StartAuthSession for TPM_SE_POLICY success! Session handle: "
+            "0x%08" PRIx32, session_handle);
+
+    /* save context */
+    g_info ("Saving context for session: 0x%" PRIxHANDLE, session_handle);
+    rc = Tss2_Sys_ContextSave (sapi_context, session_handle, &context);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("Tss2_Sys_ContextSave failed: 0x%" PRIxHANDLE, rc);
+    }
+    prettyprint_context (&context);
+    g_info ("Tearding down SAPI connection 0x%" PRIxPTR,
+            (uintptr_t)sapi_context);
+    sapi_teardown_full (sapi_context);
+
+    g_info ("Creating second SAPI context");
+    sapi_context = sapi_init_from_opts (&opts);
+    if (sapi_context == NULL) {
+        g_error ("Failed to create SAPI context.");
+    }
+    g_info ("Got SAPI context: 0x%" PRIxPTR, (uintptr_t)sapi_context);
+    /* reload the session through new connection */
+    g_info ("Loading context for session: 0x%" PRIxHANDLE, session_handle);
+    rc = Tss2_Sys_ContextLoad (sapi_context, &context, &session_handle_load);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("Tss2_Sys_ContextLoad failed: 0x%" PRIxHANDLE, rc);
+    }
+    g_info ("Successfully loaded context for session: 0x%" PRIxHANDLE,
+            session_handle_load);
+    if (session_handle_load != session_handle) {
+        g_error ("session_handle != session_handle_load");
+    }
+    sapi_teardown_full (sapi_context);
+    return 0;
+}

--- a/test/integration/session-load-from-closed-connections-lru.int.c
+++ b/test/integration/session-load-from-closed-connections-lru.int.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <inttypes.h>
+#include <glib.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <sapi/tpm20.h>
+
+#include "common.h"
+#include "tabrmd.h"
+#include "test-options.h"
+#include "context-util.h"
+
+#define PRIxHANDLE "08" PRIx32
+#define TABRMD_MAX_SESSIONS MAX_SESSIONS_DEFAULT
+#define TEST_MAX_SESSIONS (TABRMD_MAX_SESSIONS + 1)
+
+/*
+ * This test exercises the session tracking logic specifically around the
+ * requirements mentioned in section 3.7. We've started calling
+ * this "session continuation" where a saved session can be loaded by a
+ * different connection.
+ *
+ * This test is specifically designed to cause the LRU algorithm in the
+ * tabrmd to flush continued sessions associated with connections that have
+ * been closed. The LRU algorithm ensures that we have a bounded number of
+ * sessions in this intermediate state (continued but unclaimed) at any
+ * given time.
+ *
+ * To accomplish this we create a fixed number (TEST_MAX_SESSIONS) of
+ * connections with a single session created by each. Each session is saved
+ * and the connection closed. Each session should be available for another
+ * connection to load still but the number of connections created was
+ * specifically chosen to be one more than the number of unowned sessions
+ * allowed by the tabrmd. This causes one session to be closed summarily
+ * by the daemon and so the session will not be loadable by this test.
+ */
+
+typedef struct {
+    TPMI_SH_AUTH_SESSION handle;
+    TPMS_CONTEXT context;
+    bool load_success;
+} test_data_t;
+
+void
+create_connection_and_save_sessions (test_opts_t *opts,
+                                     test_data_t data [],
+                                     size_t count)
+{
+    TSS2_RC rc;
+    TSS2_SYS_CONTEXT *sapi_context;
+    size_t i;
+
+    g_info ("Creating and saving %zu policy sessions", count);
+    for (i = 0; i < count; ++i) {
+        sapi_context = sapi_init_from_opts (opts);
+        if (sapi_context == NULL) {
+            g_error ("Failed to create SAPI context.");
+        }
+        g_info ("Got SAPI context: 0x%" PRIxPTR, (uintptr_t)sapi_context);
+        /* create an auth session */
+        g_info ("Starting unbound, unsaulted auth session");
+        rc = start_auth_session (sapi_context, &data [i].handle);
+        if (rc != TSS2_RC_SUCCESS) {
+            g_error ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxHANDLE, rc);
+        }
+        g_info ("StartAuthSession for TPM_SE_POLICY success! Session handle: "
+                "0x%08" PRIx32, data [i].handle);
+
+        /* save context */
+        g_info ("Saving context for session: 0x%" PRIxHANDLE,
+                data [i].handle);
+        rc = Tss2_Sys_ContextSave (sapi_context,
+                                   data [i].handle,
+                                   &data [i].context);
+        if (rc != TSS2_RC_SUCCESS) {
+            g_error ("Tss2_Sys_ContextSave failed: 0x%" PRIxHANDLE, rc);
+        }
+        g_info ("Successfully saved context for session: 0x%" PRIxHANDLE,
+                data [i].handle);
+        prettyprint_context (&data [i].context);
+        g_info ("Tearding down SAPI connection 0x%" PRIxPTR,
+                (uintptr_t)sapi_context);
+        sapi_teardown_full (sapi_context);
+    }
+}
+/*
+ * This function attempts to load 'count' session contexts from the provided
+ * array. The handles for the loaded sessions are returned in the
+ * handle array. The number of contexts loaded is returned.
+ */
+size_t
+load_sessions (TSS2_SYS_CONTEXT *sapi_context,
+               test_data_t data [],
+               size_t count)
+{
+    TSS2_RC rc;
+    size_t i, success_count = 0;
+
+    for (i = 0; i < count; ++i) {
+        g_debug ("Loading saved context with handle: 0x%08" PRIx32,
+                 data [i].context.savedHandle);
+        rc = Tss2_Sys_ContextLoad (sapi_context,
+                                   &data [i].context,
+                                   &data [i].handle);
+        if (rc == TSS2_RC_SUCCESS) {
+            g_info ("Successfully loaded context for session: 0x%" PRIxHANDLE,
+                    data [i].handle);
+            data [i].load_success = true;
+            ++success_count;
+        } else {
+            g_warning ("Tss2_Sys_ContextLoad failed: 0x%" PRIxHANDLE, rc);
+        }
+    }
+
+    return success_count;
+}
+int
+main (int argc,
+      char *argv[])
+{
+    TSS2_SYS_CONTEXT *sapi_context;
+    test_data_t test_data [TEST_MAX_SESSIONS] = { 0 };
+    test_opts_t opts = {
+        .tcti_type      = TCTI_DEFAULT,
+        .device_file    = DEVICE_PATH_DEFAULT,
+        .socket_address = HOSTNAME_DEFAULT,
+        .socket_port    = PORT_DEFAULT,
+        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
+        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
+        .tcti_retries    = TCTI_RETRIES_DEFAULT,
+    };
+    guint success_count;
+
+    get_test_opts_from_env (&opts);
+    if (sanity_check_test_opts (&opts) != 0)
+        exit (1);
+    /* create TEST_MAX_SESSIONS each over a unique connection to the tabrmd */
+    create_connection_and_save_sessions (&opts, test_data, TEST_MAX_SESSIONS);
+    /* create fresh connection for the test */
+    sapi_context = sapi_init_from_opts (&opts);
+    if (sapi_context == NULL) {
+        g_error ("Failed to create SAPI context.");
+    }
+    /*
+     * Of the continued sessions above, only TABRMD_MAX_SESSIONS should be
+     * available to us.
+     */
+    success_count = load_sessions (sapi_context, test_data, TEST_MAX_SESSIONS);
+    if (success_count != TABRMD_MAX_SESSIONS) {
+        g_critical ("Expected to load %u sessions, got %u instead",
+                    TABRMD_MAX_SESSIONS, success_count);
+        exit (1);
+    }
+    /*
+     * The first session we created is the oldest. The LRU should have selected
+     * this one for eviction
+     */
+    if (test_data [0].load_success == true) {
+        g_critical ("Oldest session created was loaded successfully.");
+        exit (1);
+    }
+    sapi_teardown_full (sapi_context);
+
+    return 0;
+}

--- a/test/integration/session-load-from-open-connection.int.c
+++ b/test/integration/session-load-from-open-connection.int.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <inttypes.h>
+#include <glib.h>
+#include <stdio.h>
+
+#include "sapi/tpm20.h"
+
+#include "common.h"
+#include "test-options.h"
+#include "context-util.h"
+
+/*
+ * This test exercises the session tracking logic, specifically the ability
+ * / feature that allows a session created and saved over one connection to
+ * the tabrmd to be loaded from another connection.
+ * This test creates an auth session using "connection0", saves it and then
+ * loads it from "connection1" *before* "connection0" is closed.
+ */
+int
+main (int argc,
+      char *argv[])
+{
+    TSS2_RC rc;
+    TSS2_SYS_CONTEXT *sapi_context0, *sapi_context1;
+    TPMI_SH_AUTH_SESSION  session_handle = 0, session_handle_load = 0;
+    TPMS_CONTEXT          context = { 0, };
+    test_opts_t opts = {
+        .tcti_type      = TCTI_DEFAULT,
+        .device_file    = DEVICE_PATH_DEFAULT,
+        .socket_address = HOSTNAME_DEFAULT,
+        .socket_port    = PORT_DEFAULT,
+        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
+        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
+        .tcti_retries    = TCTI_RETRIES_DEFAULT,
+    };
+
+    get_test_opts_from_env (&opts);
+    if (sanity_check_test_opts (&opts) != 0)
+        exit (1);
+
+    sapi_context0 = sapi_init_from_opts (&opts);
+    if (sapi_context0 == NULL) {
+        g_error ("Failed to create SAPI context.");
+    }
+    /* create an auth session */
+    rc = start_auth_session (sapi_context0, &session_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxHANDLE, rc);
+    }
+    /* save context */
+    rc = Tss2_Sys_ContextSave (sapi_context0, session_handle, &context);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("Tss2_Sys_ContextSave failed: 0x%" PRIxHANDLE, rc);
+    }
+
+    sapi_context1 = sapi_init_from_opts (&opts);
+    if (sapi_context1 == NULL) {
+        g_error ("Failed to create SAPI context.");
+    }
+    /* reload the session through new connection */
+    rc = Tss2_Sys_ContextLoad (sapi_context1, &context, &session_handle_load);
+    if (rc != TSS2_RC_SUCCESS) {
+        g_error ("Tss2_Sys_ContextLoad failed: 0x%" PRIxHANDLE, rc);
+    }
+    if (session_handle_load == session_handle) {
+        g_info ("session_handle == session_handle_load");
+    } else {
+        g_error ("session_handle != session_handle_load");
+    }
+
+    /* teardown sapi connection */
+    sapi_teardown_full (sapi_context0);
+    sapi_teardown_full (sapi_context1);
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds support for multi-process access to sessions. Clients will now be able to:
1) load a saved session from a different tabrmd connection
2) load a saved session from a different tabrmd connection that has since been closed
3) limit the number of unowned (saved by a now closed connection, not yet loaded by aother) sessions 
The use-case driving this requirement are collaborating processes / unix shell pipelines.