### PR TITLE
test: Use built-in mock with cast functions instead of manual cast.

### DIFF
--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -57,7 +57,7 @@ __wrap_Tss2_Sys_Startup (TSS2_SYS_CONTEXT *sapi_context,
 {
     TSS2_RC rc;
 
-    rc = (TSS2_RC)mock ();
+    rc = mock_type (TSS2_RC);
     g_debug ("__wrap_Tss2_Sys_Startup returning: 0x%x", rc);
     return rc;
 }
@@ -81,12 +81,12 @@ __wrap_Tss2_Sys_GetCapability (TSS2_SYS_CONTEXT         *sysContext,
 
     capabilityData->capability = TPM_CAP_TPM_PROPERTIES;
     capabilityData->data.tpmProperties.tpmProperty[0].property = TPM_PT_MAX_COMMAND_SIZE;
-    capabilityData->data.tpmProperties.tpmProperty[0].value    = (guint32)mock ();
+    capabilityData->data.tpmProperties.tpmProperty[0].value    = mock_type (guint32);
     capabilityData->data.tpmProperties.tpmProperty[1].property = TPM_PT_MAX_RESPONSE_SIZE;
-    capabilityData->data.tpmProperties.tpmProperty[1].value    = (guint32)mock ();
+    capabilityData->data.tpmProperties.tpmProperty[1].value    = mock_type (guint32);
     capabilityData->data.tpmProperties.count = 2;
 
-    rc = (TSS2_RC)mock ();
+    rc = mock_type (TSS2_RC);
     g_debug ("__wrap_Tss2_Sys_GetCapability returning: 0x%x", rc);
     return rc;
 }
@@ -97,7 +97,7 @@ __wrap_tcti_echo_transmit (TSS2_TCTI_CONTEXT *tcti_context,
 {
     TSS2_RC rc;
 
-    rc = (TSS2_RC)mock ();
+    rc = mock_type (TSS2_RC);
     g_debug ("__wrap_tcti_echo_transmit returning: 0x%x", rc);
 
     return rc;
@@ -110,7 +110,7 @@ __wrap_tcti_echo_receive (TSS2_TCTI_CONTEXT *tcti_context,
 {
     TSS2_RC rc;
 
-    rc = (TSS2_RC)mock ();
+    rc = mock_type (TSS2_RC);
     g_debug ("__wrap_tcti_echo_receive returning: 0x%x", rc);
 
     return rc;

--- a/test/command-attrs_unit.c
+++ b/test/command-attrs_unit.c
@@ -111,7 +111,7 @@ command_attrs_type_test (void **state)
 TSS2_SYS_CONTEXT*
 __wrap_access_broker_lock_sapi (AccessBroker *access_broker)
 {
-    return (TSS2_SYS_CONTEXT*)mock ();
+    return mock_ptr_type (TSS2_SYS_CONTEXT*);
 }
 /* */
 TSS2_RC
@@ -120,9 +120,9 @@ __wrap_access_broker_get_max_command (AccessBroker *access_broker,
 {
     TSS2_RC rc;
 
-    *value = (guint)mock ();
+    *value = mock_type (guint);
     g_debug ("value: 0x%" PRIx32, *value);
-    rc = (TSS2_RC)mock ();
+    rc = mock_type (TSS2_RC);
     g_debug ("rc: 0x%" PRIx32, rc);
 
     return rc;
@@ -142,11 +142,11 @@ __wrap_Tss2_Sys_GetCapability (TSS2_SYS_CONTEXT         *sysContext,
     gint i;
 
     capabilityData->data.command.count = propertyCount;
-    command_attrs = (TPMA_CC*)mock ();
+    command_attrs = mock_ptr_type (TPMA_CC*);
     for (i = 0; i < capabilityData->data.command.count; ++i)
         capabilityData->data.command.commandAttributes[i] = command_attrs[i];
 
-    return (TSS2_RC)mock ();
+    return mock_type (TSS2_RC);
 }
 /*
  * Test case that initializes the CommandAttrs object. All wrapped

--- a/test/command-source_unit.c
+++ b/test/command-source_unit.c
@@ -69,7 +69,7 @@ __wrap_connection_manager_lookup_istream (ConnectionManager *manager,
                                           GInputStream      *istream)
 {
     g_debug ("%s", __func__);
-    return CONNECTION (mock ());
+    return CONNECTION (mock_ptr_type (GObject*));
 }
 gint
 __wrap_connection_manager_remove      (ConnectionManager  *manager,
@@ -99,7 +99,7 @@ __wrap_sink_enqueue (Sink     *sink,
     Tpm2Command **command;
 
     g_debug ("%s", __func__);
-    command = (Tpm2Command**)mock ();
+    command = mock_ptr_type (Tpm2Command**);
 
     *command = TPM2_COMMAND (obj);
     g_object_ref (*command);

--- a/test/random_unit.c
+++ b/test/random_unit.c
@@ -64,7 +64,7 @@ __wrap_open(const char *pathname,
             int         flags,
             mode_t      mode)
 {
-    return ((int)mock ());
+    return mock_type (int);
 }
 /* wrap function for the 'read' system call */
 ssize_t
@@ -72,13 +72,13 @@ __wrap_read (int     fd,
              void   *buf,
              size_t  count)
 {
-    return ((ssize_t)mock ());
+    return mock_type (ssize_t);
 }
 /* wrap function for the 'close' system call */
 int
 __wrap_close (int fd)
 {
-    return ((int)mock ());
+    return mock_type (int);
 }
 
 /* Simple test to test type checking macros. */

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -63,8 +63,8 @@ __wrap_access_broker_send_command (AccessBroker *access_broker,
 {
     Tpm2Response *response;
 
-    *rc      = (TSS2_RC)mock ();
-    response = TPM2_RESPONSE (mock ());
+    *rc      = mock_type (TSS2_RC);
+    response = TPM2_RESPONSE (mock_ptr_type (GObject*));
 
     return response;
 }
@@ -87,7 +87,7 @@ void
 __wrap_sink_enqueue (Sink      *self,
                      GObject   *obj)
 {
-    test_data_t *data = (test_data_t*)mock ();
+    test_data_t *data = mock_ptr_type (test_data_t*);
     data->response = TPM2_RESPONSE (obj);
 }
 TSS2_RC
@@ -95,7 +95,7 @@ __wrap_access_broker_context_saveflush (AccessBroker *broker,
                                         TPM_HANDLE    handle,
                                         TPMS_CONTEXT *contedt)
 {
-   return (TSS2_RC)mock ();
+   return mock_type (TSS2_RC);
 }
 /*
  * Wrap call to access_broker_context_load. Pops two parameters off the
@@ -108,8 +108,8 @@ __wrap_access_broker_context_load (AccessBroker *access_broker,
                                    TPMS_CONTEXT *context,
                                    TPM_HANDLE   *handle)
 {
-    TSS2_RC    rc      = (TSS2_RC)mock ();
-    TPM_HANDLE phandle = (TPM_HANDLE)mock ();
+    TSS2_RC    rc      = mock_type (TSS2_RC);
+    TPM_HANDLE phandle = mock_type (TPM_HANDLE);
 
     assert_non_null (handle);
     *handle = phandle;

--- a/test/tcti-device_unit.c
+++ b/test/tcti-device_unit.c
@@ -37,8 +37,8 @@ __wrap_InitDeviceTcti (TSS2_TCTI_CONTEXT   *tcti_context,
                        size_t              *size,
                        TCTI_DEVICE_CONF    *config)
 {
-    *size = (size_t) mock ();
-    return (TSS2_RC) mock ();
+    *size = mock_type (size_t);
+    return mock_type (TSS2_RC);
 }
 
 static int

--- a/test/tcti-socket_unit.c
+++ b/test/tcti-socket_unit.c
@@ -38,8 +38,8 @@ __wrap_InitSocketTcti (TSS2_TCTI_CONTEXT *tcti_context,
                        TCTI_SOCKET_CONF *config,
                        uint8_t serverSockets)
 {
-    *size = (size_t) mock ();
-    return (TSS2_RC) mock ();
+    *size = mock_type (size_t);
+    return mock_type (TSS2_RC);
 }
 
 static int

--- a/test/tss2-tcti-tabrmd_unit.c
+++ b/test/tss2-tcti-tabrmd_unit.c
@@ -99,8 +99,8 @@ __wrap_g_dbus_proxy_call_with_unix_fd_list_sync (
     gint client_fd;
     guint64 id;
 
-    client_fd = (gint)mock ();
-    id = (guint64)mock ();
+    client_fd = mock_type (gint);
+    id = mock_type (guint64);
 
     *out_fd_list = g_unix_fd_list_new_from_array (&client_fd, 1);
     variant_array[0] = g_variant_new_fixed_array (G_VARIANT_TYPE ("h"),
@@ -125,8 +125,8 @@ __wrap_tcti_tabrmd_call_cancel_sync (
     GCancellable *cancellable,
     GError **error)
 {
-    *out_return_code = (guint)mock ();
-    return (gboolean)mock ();
+    *out_return_code = mock_type (guint);
+    return mock_type (gboolean);
 }
 /*
  * This is a mock function to control behavior of the
@@ -142,8 +142,8 @@ __wrap_tcti_tabrmd_call_set_locality_sync (
     GCancellable *cancellable,
     GError **error)
 {
-    *out_return_code = (guint)mock ();
-    return (gboolean)mock ();
+    *out_return_code = mock_type (guint);
+    return mock_type (gboolean);
 }
 /*
  * Structure to hold data relevant to tabrmd TCTI unit tests.

--- a/test/util_unit.c
+++ b/test/util_unit.c
@@ -59,7 +59,7 @@ __wrap_g_output_stream_write (GOutputStream *ostream,
     if (error_tmp != NULL && error != NULL) {
         *error = error_tmp;
     }
-    return (ssize_t) mock ();
+    return mock_type (ssize_t);
 }
 
 void


### PR DESCRIPTION
This is intended to keep older versions of GCC happy.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>