### PR TITLE
autotools: distribute the template service file instead of the genera…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -119,7 +119,7 @@ EXTRA_DIST = \
     dist/tpm2-abrmd.conf \
     dist/tcti-tabrmd.pc.in \
     dist/tpm2-abrmd.preset \
-    dist/tpm2-abrmd.service \
+    dist/tpm2-abrmd.service.in \
     dist/tpm-udev.rules \
     scripts/int-log-compiler.sh \
     CHANGELOG.md \


### PR DESCRIPTION
…ted one

This fixes a bug in distribution tarballs created via `make dist`, that
caused the installed systemd service file to always contain paths
pointing to /usr/local/... instead of the actual prefixes used during
`configure` time.

Signed-off-by: Matthias Gerstner <matthias.gerstner@suse.de>