### PR TITLE
fix abrmd to work with 532

### DIFF
--- a/src/access-broker.c
+++ b/src/access-broker.c
@@ -504,8 +504,7 @@ access_broker_init_tpm (AccessBroker *broker)
     pthread_mutex_init (&broker->sapi_mutex, NULL);
     rc = access_broker_send_tpm_startup (broker);
     if (rc != TSS2_RC_SUCCESS) {
-        g_error ("access_broker_sent_tpm_startup failed: 0x%x", rc);
-        goto out;
+        g_warning ("access_broker_sent_tpm_startup failed: 0x%x", rc);
     }
     rc = access_broker_get_tpm_properties_fixed (broker->sapi_context,
                                                  &broker->properties_fixed);


### PR DESCRIPTION
Simulators 974 and 532 handle the startup routine a bit differently.
If tpm2_startup() fails, try to forward progress anyways.

Fixes:
** (tpm2-abrmd:13686): WARNING **: Tss2_Sys_Startup returned unexpected RC: 0x101

** (tpm2-abrmd:13686): ERROR **: access_broker_sent_tpm_startup failed: 0x101

Signed-off-by: William Roberts <william.c.roberts@intel.com>