### PR TITLE
Fix build error due trying to access TPMAs as struct bitfields

### DIFF
--- a/src/command-attrs.c
+++ b/src/command-attrs.c
@@ -126,7 +126,7 @@ command_attrs_init_tpm (CommandAttrs *attrs,
 }
 
 /* TPM2_CC is in the lower 15 bits of the TPMA_CC */
-#define TPM2_CC_FROM_TPMA_CC(attrs) (attrs.val & 0x7fff)
+#define TPM2_CC_FROM_TPMA_CC(attrs) (attrs & 0x7fff)
 TPMA_CC
 command_attrs_from_cc (CommandAttrs *attrs,
                        TPM2_CC        command_code)

--- a/src/resource-manager.c
+++ b/src/resource-manager.c
@@ -221,7 +221,7 @@ resource_manager_load_auth_callback (gpointer auth_offset_ptr,
     handle = tpm2_command_get_auth_handle (data->command, auth_offset);
     session_attrs = tpm2_command_get_auth_attrs (data->command,
                                                  auth_offset);
-    will_flush = session_attrs.val & TPMA_SESSION_CONTINUESESSION ? FALSE : TRUE;
+    will_flush = session_attrs & TPMA_SESSION_CONTINUESESSION ? FALSE : TRUE;
     switch (handle >> TPM2_HR_SHIFT) {
     case TPM2_HT_HMAC_SESSION:
     case TPM2_HT_POLICY_SESSION:
@@ -612,7 +612,7 @@ post_process_entry_list (ResourceManager  *resmgr,
                          TPMA_CC           command_attrs)
 {
     /* if flushed bit is clear we need to flush & save contexts */
-    if (!command_attrs.flushed) {
+    if (!(command_attrs & TPMA_CC_FLUSHED)) {
         g_debug ("flushsave_context for %" PRIu32 " entries",
                  g_slist_length (*entry_slist));
         g_slist_foreach (*entry_slist,

--- a/src/tpm2-command.c
+++ b/src/tpm2-command.c
@@ -180,7 +180,7 @@ tpm2_command_get_property (GObject     *object,
     g_debug ("tpm2_command_get_property: 0x%" PRIxPTR, (uintptr_t)self);
     switch (property_id) {
     case PROP_ATTRIBUTES:
-        g_value_set_uint (value, self->attributes.val);
+        g_value_set_uint (value, self->attributes);
         break;
     case PROP_BUFFER:
         g_value_set_pointer (value, self->buffer);
@@ -342,7 +342,7 @@ tpm2_command_get_handle_count (Tpm2Command *command)
         g_warning ("tpm2_command_get_handle_count received NULL parameter");
         return 0;
     }
-    tmp = tpm2_command_get_attributes (command).val;
+    tmp = tpm2_command_get_attributes (command);
     return (guint8)((tmp & TPMA_CC_CHANDLES) >> 25);
 }
 /*

--- a/src/tpm2-response.c
+++ b/src/tpm2-response.c
@@ -108,7 +108,7 @@ tpm2_response_get_property (GObject     *object,
     g_debug ("tpm2_response_get_property: 0x%" PRIxPTR, (uintptr_t)self);
     switch (property_id) {
     case PROP_ATTRIBUTES:
-        g_value_set_uint (value, self->attributes.val);
+        g_value_set_uint (value, self->attributes);
         break;
     case PROP_BUFFER:
         g_value_set_pointer (value, self->buffer);
@@ -292,7 +292,7 @@ tpm2_response_has_handle (Tpm2Response  *response)
     if (tpm2_response_get_size (response) < TPM_HEADER_SIZE) {
         return FALSE;
     } else {
-        tmp = tpm2_response_get_attributes (response).val;
+        tmp = tpm2_response_get_attributes (response);
         return tmp & TPMA_CC_RHANDLE ? TRUE : FALSE;
     }
 }

--- a/src/util.c
+++ b/src/util.c
@@ -327,14 +327,14 @@ create_socket_pair (int *fd_a,
 void
 g_debug_tpma_cc (TPMA_CC tpma_cc)
 {
-    g_debug ("TPMA_CC: 0x%08" PRIx32, tpma_cc.val);
-    g_debug ("  commandIndex: 0x%" PRIx16, tpma_cc.val & TPMA_CC_COMMANDINDEX);
-    g_debug ("  reserved1:    0x%" PRIx8, (tpma_cc.val & TPMA_CC_RESERVED1) >> 16);
-    g_debug ("  nv:           %s", prop_str (tpma_cc.val & TPMA_CC_NV));
-    g_debug ("  extensive:    %s", prop_str (tpma_cc.val & TPMA_CC_EXTENSIVE));
-    g_debug ("  flushed:      %s", prop_str (tpma_cc.val & TPMA_CC_FLUSHED));
-    g_debug ("  cHandles:     0x%" PRIx8, (tpma_cc.val & TPMA_CC_CHANDLES) >> 25);
-    g_debug ("  rHandle:      %s", prop_str (tpma_cc.val & TPMA_CC_RHANDLE));
-    g_debug ("  V:            %s", prop_str (tpma_cc.val & TPMA_CC_V));
-    g_debug ("  Res:          0x%" PRIx8, (tpma_cc.val & TPMA_CC_RES) >> 30);
+    g_debug ("TPMA_CC: 0x%08" PRIx32, tpma_cc);
+    g_debug ("  commandIndex: 0x%" PRIx16, tpma_cc & TPMA_CC_COMMANDINDEX);
+    g_debug ("  reserved1:    0x%" PRIx8, (tpma_cc & TPMA_CC_RESERVED1) >> 16);
+    g_debug ("  nv:           %s", prop_str (tpma_cc & TPMA_CC_NV));
+    g_debug ("  extensive:    %s", prop_str (tpma_cc & TPMA_CC_EXTENSIVE));
+    g_debug ("  flushed:      %s", prop_str (tpma_cc & TPMA_CC_FLUSHED));
+    g_debug ("  cHandles:     0x%" PRIx8, (tpma_cc & TPMA_CC_CHANDLES) >> 25);
+    g_debug ("  rHandle:      %s", prop_str (tpma_cc & TPMA_CC_RHANDLE));
+    g_debug ("  V:            %s", prop_str (tpma_cc & TPMA_CC_V));
+    g_debug ("  Res:          0x%" PRIx8, (tpma_cc & TPMA_CC_RES) >> 30);
 }

--- a/test/command-attrs_unit.c
+++ b/test/command-attrs_unit.c
@@ -65,16 +65,9 @@ command_attrs_init_tpm_setup (void **state)
 {
     test_data_t *data;
     gint         ret;
-    TPMA_CC      hierarchy_attrs  = { .val = TPM2_CC_HierarchyControl + 0xff0000 };
-    TPMA_CC      change_pps_attrs = { .val = TPM2_CC_ChangePPS + 0xff0000 };
-    TPMA_CC      command_attributes [2] = {
-        {
-            .val = hierarchy_attrs.val,
-        },
-        {
-            .val = change_pps_attrs.val,
-        },
-    };
+    TPMA_CC      hierarchy_attrs  = TPM2_CC_HierarchyControl + 0xff0000;
+    TPMA_CC      change_pps_attrs = TPM2_CC_ChangePPS + 0xff0000;
+    TPMA_CC      command_attributes [2] = { hierarchy_attrs, change_pps_attrs };
 
     command_attrs_setup (state);
     data = *state;
@@ -157,14 +150,7 @@ command_attrs_init_tpm_success_test (void **state)
 {
     test_data_t *data = *state;
     gint         ret = -1;
-    TPMA_CC      command_attributes [2] = {
-        {
-            .val = 0xdeadbeef,
-        },
-        {
-            .val = 0xfeebdaed,
-        },
-    };
+    TPMA_CC      command_attributes [2] = { 0xdeadbeef, 0xfeebdaed };
 
     will_return (__wrap_access_broker_lock_sapi, 1);
     will_return (__wrap_access_broker_get_max_command, 2);
@@ -237,14 +223,7 @@ command_attrs_init_tpm_fail_get_capability_test (void **state)
 {
     test_data_t *data = *state;
     gint         ret = -1;
-    TPMA_CC      command_attributes [2] = {
-        {
-            .val = 0xdeadbeef,
-        },
-        {
-            .val = 0xfeebdaed,
-        },
-    };
+    TPMA_CC      command_attributes [2] = { 0xdeadbeef, 0xfeebdaed };
 
     will_return (__wrap_access_broker_lock_sapi, 1);
     will_return (__wrap_access_broker_get_max_command, 2);
@@ -272,7 +251,7 @@ command_attrs_from_cc_success_test (void **state)
      */
     ret_attrs = command_attrs_from_cc (data->command_attrs,
                                        TPM2_CC_HierarchyControl);
-    assert_int_equal (ret_attrs.val & 0x7fff, TPM2_CC_HierarchyControl);
+    assert_int_equal (ret_attrs & 0x7fff, TPM2_CC_HierarchyControl);
 }
 /*
  * Test a failed call to the command_attrs_from_cc function. This relies
@@ -292,7 +271,7 @@ command_attrs_from_cc_fail_test (void **state)
      */
     ret_attrs = command_attrs_from_cc (data->command_attrs,
                                        TPM2_CC_EvictControl);
-    assert_int_equal (ret_attrs.val, 0);
+    assert_int_equal (ret_attrs, 0);
 }
 gint
 main (gint    argc,

--- a/test/integration/common.c
+++ b/test/integration/common.c
@@ -128,7 +128,7 @@ create_primary (TSS2_SYS_CONTEXT *sapi_context,
     /* TPMI_ALG_HASH / nameAlg */
     in_public.publicArea.nameAlg = TPM2_ALG_SHA256;
     /* TPMA_OBJECT / objectAttributes */
-    in_public.publicArea.objectAttributes.val = \
+    in_public.publicArea.objectAttributes = \
         TPMA_OBJECT_FIXEDTPM            | TPMA_OBJECT_FIXEDPARENT  | \
         TPMA_OBJECT_SENSITIVEDATAORIGIN | TPMA_OBJECT_USERWITHAUTH | \
         TPMA_OBJECT_RESTRICTED          | TPMA_OBJECT_DECRYPT;
@@ -196,7 +196,7 @@ create_key (TSS2_SYS_CONTEXT *sapi_context,
     in_sensitive.size = in_sensitive.sensitive.userAuth.size + 2;
     in_public.publicArea.type = TPM2_ALG_RSA;
     in_public.publicArea.nameAlg = TPM2_ALG_SHA256;
-    in_public.publicArea.objectAttributes.val = \
+    in_public.publicArea.objectAttributes = \
         TPMA_OBJECT_FIXEDTPM            | TPMA_OBJECT_FIXEDPARENT  | \
         TPMA_OBJECT_SENSITIVEDATAORIGIN | TPMA_OBJECT_USERWITHAUTH | \
         TPMA_OBJECT_DECRYPT             | TPMA_OBJECT_SIGN;

--- a/test/integration/password-authorization.int.c
+++ b/test/integration/password-authorization.int.c
@@ -80,9 +80,9 @@ CreatePasswordTestNV (TSS2_SYS_CONTEXT   *sapi_context,
     *(UINT32 *)&( publicInfo.nvPublic.attributes ) = 0;
 
     // Now set the attributes.
-    publicInfo.nvPublic.attributes.TPMA_NV_AUTHREAD = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_AUTHWRITE = 1;
-    publicInfo.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_AUTHREAD;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_AUTHWRITE;
+    publicInfo.nvPublic.attributes |= TPMA_NV_TPMA_NV_ORDERLY;
     publicInfo.nvPublic.authPolicy.size = 0;
     publicInfo.nvPublic.dataSize = 32;
 

--- a/test/resource-manager_unit.c
+++ b/test/resource-manager_unit.c
@@ -156,7 +156,7 @@ resource_manager_setup_two_transient_handles (void **state)
 
     data->vhandles [0] = TPM2_HR_TRANSIENT + 0x1;
     data->vhandles [1] = TPM2_HR_TRANSIENT + 0x2;
-    data->command_attrs.val = (2 << 25) + TPM2_CC_StartAuthSession; /* 2 handles + TPM2_StartAuthSession */
+    data->command_attrs = (2 << 25) + TPM2_CC_StartAuthSession; /* 2 handles + TPM2_StartAuthSession */
 
     /* create Tpm2Command that we'll be transforming */
     buffer_size = TPM_HEADER_SIZE + 2 * sizeof (TPM2_HANDLE);

--- a/test/tpm2-command_unit.c
+++ b/test/tpm2-command_unit.c
@@ -116,9 +116,7 @@ static int
 tpm2_command_setup (void **state)
 {
     test_data_t *data   = NULL;
-    TPMA_CC  attributes = {
-        .val = 0x0,
-    };
+    TPMA_CC  attributes = 0x0;
 
     tpm2_command_setup_base (state);
     data = (test_data_t*)*state;
@@ -133,9 +131,7 @@ static int
 tpm2_command_setup_two_handles (void **state)
 {
     test_data_t *data = NULL;
-    TPMA_CC  attributes = {
-       .val = 2 << 25,
-    };
+    TPMA_CC  attributes = 2 << 25;
 
     tpm2_command_setup_base (state);
     data = (test_data_t*)*state;
@@ -205,9 +201,7 @@ tpm2_command_setup_with_auths (void **state)
     gint         client_fd;
     GIOStream   *iostream;
     HandleMap   *handle_map;
-    TPMA_CC attributes = {
-        .val = 2 << 25,
-    };
+    TPMA_CC attributes = 2 << 25;
 
     data = calloc (1, sizeof (test_data_t));
     /* allocate a buffer large enough to hold the cmd_with_auths buffer */
@@ -234,9 +228,7 @@ tpm2_command_setup_flush_context_no_handle (void **state)
     gint         client_fd;
     GIOStream   *iostream;
     HandleMap   *handle_map;
-    TPMA_CC attributes = {
-        .val = 2 << 25,
-    };
+    TPMA_CC attributes = 2 << 25;
 
     data = calloc (1, sizeof (test_data_t));
     /* allocate a buffer large enough to hold the cmd_with_auths buffer */

--- a/test/tpm2-response_unit.c
+++ b/test/tpm2-response_unit.c
@@ -95,9 +95,7 @@ static int
 tpm2_response_setup_with_handle (void **state)
 {
     test_data_t *data;
-    TPMA_CC attributes = {
-        .val = 1 << 28,
-    };
+    TPMA_CC attributes = 1 << 28;
 
     tpm2_response_setup_base (state);
     data = (test_data_t*)*state;


### PR DESCRIPTION
The SAPI library doesn't support anymore to access TPMAs as struct bitfields.
This causes a lot of build errors when building against the latest tpm2-tss.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>