### PR TITLE
build: Add uninstall-local target to catch files missed by the defaul…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,10 @@ if WITH_UDEVRULESPREFIX
 	mv $(DESTDIR)$(udevrulesdir)/tpm-udev.rules $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
 endif
 
+uninstall-local:
+	-rm $(DESTDIR)$(mandir)/man3/tss2_tcti_tabrmd_init_full.3
+	-rm $(DESTDIR)$(udevrulesdir)/$(udevrulesprefix)tpm-udev.rules
+
 libtcti_tabrmddir      = $(includedir)/tcti
 libtcti_tabrmd_HEADERS = $(srcdir)/src/include/tcti-tabrmd.h
 


### PR DESCRIPTION
…t rule.

Files left behind by the default rule are all special cases:
1) The tss2_tcti_tabrmd_init_full.3 man page is a soft link that we create
at install time.
2) If the udev rules file prefix is provided @ configure time then we
rename the file at install time.

The solution is the same for both: use the uninstall-local target.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>