### PR TITLE
test: update to the new SYS_AUTH_COMMAND SYS_AUTH_RESPONSE structs

### DIFF
--- a/test/access-broker_unit.c
+++ b/test/access-broker_unit.c
@@ -68,13 +68,13 @@ __wrap_Tss2_Sys_Startup (TSS2_SYS_CONTEXT *sapi_context,
  */
 TSS2_RC
 __wrap_Tss2_Sys_GetCapability (TSS2_SYS_CONTEXT         *sysContext,
-                               TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+                               TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
                                TPM2_CAP                  capability,
                                UINT32                    property,
                                UINT32                    propertyCount,
                                TPMI_YES_NO              *moreData,
                                TPMS_CAPABILITY_DATA     *capabilityData,
-                               TSS2_SYS_RSP_AUTHS       *rspAuthsArray)
+                               TSS2L_SYS_AUTH_RESPONSE  *rspAuthsArray)
 
 {
     TSS2_RC rc;

--- a/test/command-attrs_unit.c
+++ b/test/command-attrs_unit.c
@@ -123,13 +123,13 @@ __wrap_access_broker_get_max_command (AccessBroker *access_broker,
 /* */
 TSS2_RC
 __wrap_Tss2_Sys_GetCapability (TSS2_SYS_CONTEXT         *sysContext,
-                               TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
+                               TSS2L_SYS_AUTH_COMMAND const *cmdAuthsArray,
                                TPM2_CAP                   capability,
                                UINT32                    property,
                                UINT32                    propertyCount,
                                TPMI_YES_NO              *moreData,
                                TPMS_CAPABILITY_DATA     *capabilityData,
-                               TSS2_SYS_RSP_AUTHS       *rspAuthsArray)
+                               TSS2L_SYS_AUTH_RESPONSE  *rspAuthsArray)
 {
     TPMA_CC *command_attrs;
     gint i;

--- a/test/integration/common.c
+++ b/test/integration/common.c
@@ -113,11 +113,11 @@ create_primary (TSS2_SYS_CONTEXT *sapi_context,
     TPMT_TK_CREATION       creation_ticket = { 0 };
     TPM2B_NAME             name            = TPM2B_NAME_STATIC_INIT;
     /* command auth stuff */
-    TPMS_AUTH_COMMAND auth_command = { .sessionHandle = TPM2_RS_PW, };
-    TPMS_AUTH_COMMAND *auth_command_array[1] = { &auth_command, };
-    TSS2_SYS_CMD_AUTHS cmd_auths = {
-        .cmdAuthsCount = 1,
-        .cmdAuths      = auth_command_array,
+    TSS2L_SYS_AUTH_COMMAND cmd_auths = {
+        .count = 1,
+        .auths = {{
+            .sessionHandle = TPM2_RS_PW,
+        }}
     };
 
     /* prepare in_sensitive */
@@ -185,11 +185,11 @@ create_key (TSS2_SYS_CONTEXT *sapi_context,
     TPM2B_CREATION_DATA	    creation_data    = { 0 };
     TPM2B_DIGEST	    creation_hash    = TPM2B_DIGEST_STATIC_INIT;
     TPMT_TK_CREATION	    creation_ticket  = { 0 };
-    TPMS_AUTH_COMMAND auth_command           = { .sessionHandle = TPM2_RS_PW, };
-    TPMS_AUTH_COMMAND *auth_command_array[1] = { &auth_command, };
-    TSS2_SYS_CMD_AUTHS cmd_auths = {
-        .cmdAuthsCount = 1,
-        .cmdAuths      = auth_command_array,
+    TSS2L_SYS_AUTH_COMMAND cmd_auths = {
+        .count = 1,
+        .auths = {{
+            .sessionHandle = TPM2_RS_PW,
+        }}
     };
 
     g_debug ("create_key with parent_handle: 0x%" PRIx32, parent_handle);
@@ -249,11 +249,11 @@ load_key (TSS2_SYS_CONTEXT *sapi_context,
 {
     TSS2_RC            rc;
     TPM2B_NAME         name                  = TPM2B_NAME_STATIC_INIT;
-    TPMS_AUTH_COMMAND  auth_command          = { .sessionHandle = TPM2_RS_PW, };
-    TPMS_AUTH_COMMAND *auth_command_array[1] = { &auth_command, };
-    TSS2_SYS_CMD_AUTHS cmd_auths             = {
-        .cmdAuthsCount = 1,
-        .cmdAuths      = auth_command_array,
+    TSS2L_SYS_AUTH_COMMAND cmd_auths = {
+        .count = 1,
+        .auths = {{
+            .sessionHandle = TPM2_RS_PW,
+        }}
     };
 
     g_print ("Tss2_Sys_Load with parent handle: 0x%" PRIx32 "\n  in_private: "
@@ -283,11 +283,11 @@ undefine_nv_index (TSS2_SYS_CONTEXT *sapi_context,
                    TPM2_HANDLE        index)
 {
     TSS2_RC rc;
-    TPMS_AUTH_COMMAND  auth_command          = { .sessionHandle = TPM2_RS_PW, };
-    TPMS_AUTH_COMMAND *auth_command_array[1] = { &auth_command, };
-    TSS2_SYS_CMD_AUTHS cmd_auths             = {
-        .cmdAuthsCount = 1,
-        .cmdAuths      = auth_command_array,
+    TSS2L_SYS_AUTH_COMMAND cmd_auths = {
+        .count = 1,
+        .auths = {{
+            .sessionHandle = TPM2_RS_PW,
+        }}
     };
 
     g_debug ("undefine_nv_index: sapi_context: 0x%" PRIxPTR " index: 0x%"
@@ -355,11 +355,11 @@ evict_persistent_objs (TSS2_SYS_CONTEXT *sapi_context,
                        TPM2_HANDLE        handle)
 {
     TSS2_RC rc;
-    TPMS_AUTH_COMMAND  auth_command          = { .sessionHandle = TPM2_RS_PW, };
-    TPMS_AUTH_COMMAND *auth_command_array[1] = { &auth_command, };
-    TSS2_SYS_CMD_AUTHS cmd_auths             = {
-        .cmdAuthsCount = 1,
-        .cmdAuths      = auth_command_array,
+    TSS2L_SYS_AUTH_COMMAND cmd_auths = {
+        .count = 1,
+        .auths = {{
+            .sessionHandle = TPM2_RS_PW,
+        }}
     };
 
     g_debug ("evict_persistent_objs: sapi_context: 0x%" PRIxPTR

--- a/test/integration/hash-sequence.int.c
+++ b/test/integration/hash-sequence.int.c
@@ -123,33 +123,24 @@ int
 test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 {
     int i;
-
     TSS2_RC rval;
+    TPMI_DH_OBJECT  sequenceHandle[MAX_TEST_SEQUENCES];
+    TPM2B_MAX_BUFFER dataToHash;
+    TPM2B_DIGEST result;
+    TPMT_TK_HASHCHECK validation;
     TPM2B_AUTH auth = {
         .size = 2,
         .buffer = { 0x00, 0xff },
     };
 
-    TPMI_DH_OBJECT  sequenceHandle[MAX_TEST_SEQUENCES];
-    TPM2B_MAX_BUFFER dataToHash;
-    TPM2B_DIGEST result;
-    TPMT_TK_HASHCHECK validation;
-
-    TPMS_AUTH_COMMAND auth_command = {
-        .sessionHandle = TPM2_RS_PW,
-        .hmac = auth,
+    TSS2L_SYS_AUTH_COMMAND cmd_auths = {
+        .count = 1,
+        .auths = {{
+            .sessionHandle = TPM2_RS_PW,
+            .hmac = auth,
+        }}
     };
-    TPMS_AUTH_COMMAND *auth_command_array[1] = { &auth_command, };
-    TSS2_SYS_CMD_AUTHS cmd_auths = {
-        .cmdAuthsCount = 1,
-        .cmdAuths      = auth_command_array,
-    };
-    TPMS_AUTH_RESPONSE  auth_response = { 0 };
-    TPMS_AUTH_RESPONSE *auth_response_array[1] = { &auth_response };
-    TSS2_SYS_RSP_AUTHS  rsp_auths = {
-        .rspAuths      = auth_response_array,
-        .rspAuthsCount = 1
-    };
+    TSS2L_SYS_AUTH_RESPONSE rsp_auths;
 
     rval = Tss2_Sys_HashSequenceStart (sapi_context,
                                        0,


### PR DESCRIPTION
Update tests to the new TSS2L_SYS_AUTH_COMMAND
and TSS2L_SYS_AUTH_RESPONSE structures.
This is to reflect the change it TSS:
https://github.com/intel/tpm2-tss/pull/634