### PR TITLE
Enable silent-rules configure option by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -261,48 +261,48 @@ src_tpm2_abrmd_LDADD   = $(DBUS_LIBS) $(GIO_LIBS) $(GLIB_LIBS) $(PTHREAD_LIBS) \
 src_tpm2_abrmd_SOURCES = src/tabrmd.c
 
 man/man3/%.3 : man/%.3.in
-	$(call man_tcti_prefix,$@,$^)
+	$(AM_V_GEN)$(call man_tcti_prefix,$@,$^)
 
 man/man7/%.7 : man/%.7.in
-	$(call man_tcti_prefix,$@,$^)
+	$(AM_V_GEN)$(call man_tcti_prefix,$@,$^)
 
 man/man8/%.8 : man/%.8.in
-	$(call man_tcti_prefix,$@,$^)
+	$(AM_V_GEN)$(call man_tcti_prefix,$@,$^)
 
 # this function is used to generate man pages from templates found in
 # $(srcdir)/man/*.in
 define man_tcti_prefix
 	$(call make_parent_dir,$@)
-	-rm -f $@
+	-$(AM_V_at)rm -f $@
 if TCTI_DEVICE
-	echo ".nr HAVE_DEVICE_TCTI 1" >> $1
+	$(AM_V_at)echo ".nr HAVE_DEVICE_TCTI 1" >> $1
 else
-	echo ".nr HAVE_DEVICE_TCTI 0" >> $1
+	$(AM_V_at)echo ".nr HAVE_DEVICE_TCTI 0" >> $1
 endif
 if TCTI_SOCKET
-	echo ".nr HAVE_SOCKET_TCTI 1" >> $1
+	$(AM_V_at)echo ".nr HAVE_SOCKET_TCTI 1" >> $1
 else
-	echo ".nr HAVE_SOCKET_TCTI 0" >> $1
+	$(AM_V_at)echo ".nr HAVE_SOCKET_TCTI 0" >> $1
 endif
-	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g;" $2 $(srcdir)/man/colophon.in >> $1
+	$(AM_V_GEN)sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g;" $2 $(srcdir)/man/colophon.in >> $1
 endef # man_tcti_prefix
 
 %-generated.c %-generated.h : src/tabrmd.xml
-	$(call make_parent_dir,$@)
+	$(AM_V_GEN)$(call make_parent_dir,$@) && \
 	$(GDBUS_CODEGEN) --interface-prefix=com.intel.tss2. \
 	    --generate-c-code=src/tabrmd-generated $^
 
 %.preset : %.preset.in
-	$(call make_parent_dir,$@)
+	$(AM_V_GEN)$(call make_parent_dir,$@) && \
 	sed -e "s,[@]SYSTEMD_PRESET_DEFAULT[@],$(SYSTEMD_PRESET_DEFAULT),g;" $^ > $@
 
 %.service : %.service.in
-	$(call make_parent_dir,$@)
+	$(AM_V_GEN)$(call make_parent_dir,$@) && \
 	sed -e "s,[@]SBINDIR[@],$(sbindir),g; \
 	        s,[@]sysconfdir[@],$(sysconfdir),g;" $^ > $@
 
 %.pc : %.pc.in
-	$(call make_parent_dir,$@)
+	$(AM_V_GEN)$(call make_parent_dir,$@) && \
 	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g; \
                 s,[@]includedir[@],$(includedir),g;" $^ > $@
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -273,7 +273,7 @@ man/man8/%.8 : man/%.8.in
 # $(srcdir)/man/*.in
 define man_tcti_prefix
 	$(call make_parent_dir,$@)
-	-rm $@
+	-rm -f $@
 if TCTI_DEVICE
 	echo ".nr HAVE_DEVICE_TCTI 1" >> $1
 else

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,8 @@ AC_PROG_CC
 AC_PROG_LN_S
 LT_INIT()
 AM_INIT_AUTOMAKE([foreign subdir-objects])
+# enable "silent-rules" option by default
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_FILES([Makefile])
 
 # propagate configure arguments to distcheck


### PR DESCRIPTION
This pull request by inspired by the same change done by @AndreasFuchsSIT in the tpm2-tss project. 

The first commit is just a trivial fix and the second one enables the silent-rules option by default and prefix commands with AM_V_{GEN,at} to reduce the output.