### PR TITLE
travis.yml: Install ax_code_coverage macro to fix tpm2-tss build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,10 @@ install:
   - popd
   - git clone -b master --single-branch https://github.com/01org/tpm2-tss.git
   - pushd tpm2-tss
+  - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2017.09.28.tar.xz
+  - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
+  - tar xJf autoconf-archive-2017.09.28.tar.xz
+  - cp autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
   - ./bootstrap
   - ./configure --prefix=${PREFIX}
   - make -j$(nproc) install


### PR DESCRIPTION
The tpm2-tss project now has support for test coverage using the autoconf
AX_CODE_COVERAGE macro but this macro isn't available in the Ubuntu image
used by Travis CI so tpm2-tss fails to build.

Fix it by downloading autoconf-archive and installing the missing macro.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>