### PR TITLE
.travis.yml: Build and install latest autoconf-archive from source.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
     - coverity_scan_run_condition='"$CC" = gcc'
     - PREFIX=/usr
     - DESTDIR="${TRAVIS_BUILD_DIR}/destdir"
+    - ACLOCAL_PATH="${DESTDIR}${PREFIX}/share/aclocal:${ACLOCAL_PATH}"
     - PKG_CONFIG_PATH="${DESTDIR}${PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
     - LD_LIBRARY_PATH="${DESTDIR}${PREFIX}/lib:${LD_LIBRARY_PATH}"
     - CFLAGS="-I${DESTDIR}${PREFIX}/include"
@@ -43,6 +44,12 @@ env:
 
 install:
   - mkdir ${DESTDIR}
+  - wget http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2017.09.28.tar.xz
+  - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
+  - tar xJf autoconf-archive-2017.09.28.tar.xz
+  - pushd autoconf-archive-2017.09.28
+  - ./configure --prefix=${PREFIX} && make && make install
+  - popd
   - wget https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz
   - tar -Jxvf cmocka-1.1.1.tar.xz
   - mkdir cmocka-1.1.1/build && pushd cmocka-1.1.1/build


### PR DESCRIPTION
The old version shipped on the travis-ci systems is very old. This will
be required for doing stuff with gcov / lcov.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>