### PR TITLE
build: Collect test coverage metrics using AX_CODE_COVERAGE.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .dirstamp
 .libs/
 tmp/
+*.gcda
+*.gcno
 *.la
 *.lo
 *.log
@@ -45,4 +47,6 @@ test/integration/*
 !test/integration/*.h
 dist/*.preset
 dist/*.service
+tpm2-abrmd-*-coverage.info
+tpm2-abrmd-*-coverage/*
 VERSION

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,8 +10,9 @@ unit-count: check
 AM_CFLAGS = $(EXTRA_CFLAGS) \
     -I$(srcdir)/src -I$(srcdir)/src/include -I$(builddir)/src \
     $(DBUS_CFLAGS) $(GIO_CFLAGS) $(GLIB_CFLAGS) $(PTHREAD_CFLAGS) \
-    $(SAPI_CFLAGS) $(TCTI_DEVICE_CFLAGS) $(TCTI_SOCKET_CFLAGS)
-AM_LDFLAGS = $(EXTRA_LDFLAGS)
+    $(SAPI_CFLAGS) $(TCTI_DEVICE_CFLAGS) $(TCTI_SOCKET_CFLAGS) \
+    $(CODE_COVERAGE_CFLAGS)
+AM_LDFLAGS = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 UNIT_AM_CFLAGS = $(AM_CFLAGS) $(CMOCKA_CFLAGS)
 
 if UNIT
@@ -156,6 +157,7 @@ systemdsystemunit_DATA = dist/tpm2-abrmd.service
 endif # HAVE_SYSTEMD
 systemdpreset_DATA = dist/tpm2-abrmd.preset
 
+@CODE_COVERAGE_RULES@
 @VALGRIND_CHECK_RULES@
 VALGRIND_G_DEBUG = fatal-criticals,gc-friendly
 VALGRIND_memcheck_FLAGS = --leak-check=full --show-leak-kinds=definite,indirect --track-origins=yes --error-exitcode=1 --suppressions=dist/tabrmd.sup

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,8 @@ AC_PATH_PROG([GDBUS_CODEGEN], [`$PKG_CONFIG --variable=gdbus_codegen gio-2.0`])
 if test -z "$GDBUS_CODEGEN"; then
     AC_MSG_ERROR([*** gdbus-codegen is required to build tpm2-abrmd])
 fi
+
+AX_CODE_COVERAGE
 # disable helgrind and drd, they hate GAsyncQueue
 AX_VALGRIND_DFLT([sgcheck], [off])
 AX_VALGRIND_DFLT([helgrind], [off])


### PR DESCRIPTION
This adds the '--enable-code-coverage' option to the configure script.
If this option is provided then the script will check for dependencies
and enable the 'check-code-coverage' make target. This will produce the
usual gcov & lcov output.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>