### PR TITLE
[master] test: support to run the test on a real TPM hardware

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,8 @@ and executed.
 * cmocka unit test framework
 * Microsoft / IBM Software TPM2 simulator version 532 as packaged by IBM:
 https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar
+* Alternately, run the test suite on a real TPM hardware, with a safety
+attention described below.
 
 # System User & Group
 As is common security practice we encourage *everyone* to run the `tpm2-abrmd`
@@ -184,6 +186,13 @@ $ ./configure --with-simulatorbin=/path/to/tpm_server
 If the configure script is able to find the executable you provide through this
 option then executing `make check` will cause the integration tests to be built
 and executed.
+
+If the executable is not found, or this option is not specified, the integration
+tests are assumed to be executed with a real TPM hardware.
+***** ATTENTION *****
+If this test suite is executed against a TPM it may cause damage to the TPM (NV
+storage and private key wear out etc).
+You have been warned.
 
 # Compilation
 Compiling the code requires running `make`. You may provide `make` whatever

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,10 +2,15 @@
 VPATH = $(srcdir) $(builddir)
 ACLOCAL_AMFLAGS = -I m4
 
-.PHONY: unit-count
+.PHONY: unit-count check-warn-user
 
 unit-count: check
 	sh scripts/unit-count.sh
+
+check-warn-user:
+if HWTPM
+	@sh $(srcdir)/scripts/warn-user.sh
+endif
 
 AM_CFLAGS = $(EXTRA_CFLAGS) \
     -I$(srcdir)/src -I$(srcdir)/src/include -I$(builddir)/src \
@@ -46,8 +51,7 @@ if TCTI_SOCKET
 endif
 endif #UNIT
 
-if SIMULATOR_BIN
-TESTS_INTEGRATION = \
+tests_integration = \
     test/integration/auth-session-max.int \
     test/integration/auth-session-start-flush.int \
     test/integration/auth-session-start-save.int \
@@ -68,6 +72,13 @@ TESTS_INTEGRATION = \
     test/integration/password-authorization.int \
     test/integration/tpm2-command-flush-no-handle.int \
     test/integration/util-buf-max-upper-bound.int
+
+if SIMULATOR_BIN
+TESTS_INTEGRATION = $(tests_integration)
+endif
+
+if HWTPM
+TESTS_INTEGRATION = $(tests_integration)
 endif
 
 XFAIL_TESTS = \
@@ -77,10 +88,17 @@ XFAIL_TESTS = \
 TESTS = $(TESTS_UNIT) $(TESTS_INTEGRATION)
 TEST_EXTENSIONS = .int
 INT_LOG_COMPILER = $(srcdir)/scripts/int-log-compiler.sh
-INT_LOG_FLAGS = --simulator-bin=$(SIMULATOR_BIN) --tabrmd-bin=$(sbin_PROGRAMS)
+INT_LOG_FLAGS = --tabrmd-bin=$(sbin_PROGRAMS)
+if SIMULATOR_BIN
+INT_LOG_FLAGS += --simulator-bin=$(SIMULATOR_BIN)
+endif
 
 sbin_PROGRAMS   = src/tpm2-abrmd
 check_PROGRAMS  = $(sbin_PROGRAMS) $(TESTS)
+noinst_SCRIPTS  = scripts/warn-user.sh
+if HWTPM
+check_SCRIPTS   = check-warn-user
+endif
 
 # libraries
 libtcti_tabrmd = src/libtcti-tabrmd.la
@@ -126,6 +144,7 @@ EXTRA_DIST = \
     dist/tpm2-abrmd.service.in \
     dist/tpm-udev.rules \
     scripts/int-log-compiler.sh \
+    scripts/warn-user.sh \
     CHANGELOG.md \
     CONTRIBUTING.md \
     INSTALL.md \

--- a/configure.ac
+++ b/configure.ac
@@ -135,9 +135,22 @@ AC_ARG_WITH([simulatorbin],
                    [AC_MSG_RESULT([no])
                     AC_MSG_ERROR([Simulator binary provided does not exist or not executable. Check path: $with_simulatorbin])])],
             [AC_MSG_RESULT([no])
-             AC_MSG_WARN([No simulator binary provided. Integration tests disabled.])
              with_simulatorbin_set=no])
 AM_CONDITIONAL([SIMULATOR_BIN],[test "x$with_simulatorbin_set" = "xyes"])
+#
+# Real TPM hardware
+#
+AC_ARG_ENABLE([test-hwtpm],
+              [AS_HELP_STRING([--enable-test-hwtpm],
+                  [enable the integration test on a real tpm hardware (default is no)])],
+              [enable_hwtpm=$enableval],
+              [enable_hwtpm=no])
+AS_IF([test \( "x$with_simulatorbin_set" = "xyes" \) -a \( "x$enable_hwtpm" = "xyes" \) ],
+      AC_MSG_ERROR([Simulator binary and real tpm hardware cannot be both enabled.]))
+AM_CONDITIONAL([HWTPM], [test "x$enable_hwtpm" != xno])
+
+AS_IF([test \( "x$with_simulatorbin_set" = "xno" \) -a \( "x$enable_hwtpm" = "xno" \) ],
+      AC_MSG_WARN([No simulator binary or tpm hardware provided. Integration tests disabled.]))
 
 # preprocessor / compiler / linker flags
 #   these macros are defined in m4/flags.m4

--- a/scripts/int-log-compiler.sh
+++ b/scripts/int-log-compiler.sh
@@ -135,9 +135,14 @@ tabrmd_start ()
     local tabrmd_name=$3
     local tabrmd_log_file=$4
     local tabrmd_pid_file=$5
-
     local tabrmd_env="G_MESSAGES_DEBUG=all"
-    local tabrmd_opts="--tcti=socket --tcti-socket-port=${tabrmd_port} --session --dbus-name=${tabrmd_name} --fail-on-loaded-trans"
+    local tabrmd_opts="--dbus-name=${tabrmd_name} --fail-on-loaded-trans"
+
+    if [ "$tabrmd_port" != "0" ]; then
+        tabrmd_opts="--tcti=socket --tcti-socket-port=${tabrmd_port} --session $tabrmd_opts"
+    else
+        tabrmd_opts="--tcti=device --allow-root $tabrmd_opts"
+    fi
 
     daemon_start "${tabrmd_bin}" "${tabrmd_opts}" "${tabrmd_log_file}" \
         "${tabrmd_pid_file}" "${tabrmd_env}" "${VALGRIND}" "${LOG_FLAGS}"
@@ -179,8 +184,15 @@ TEST_DIR=$(dirname "$1")
 TEST_NAME=$(basename "${TEST_BIN}")
 
 # sanity tests
-if [ ! -x "${SIM_BIN}" ]; then
-    echo "no simulator binary provided or not executable"
+if [ -n "${SIM_BIN}" ]; then
+    if [ ! -x "${SIM_BIN}" ]; then
+        echo "no simulator binary provided or not executable"
+        exit 1
+    fi
+fi
+
+if [ \( -z "${SIM_BIN}" \) -a \( `id -u` != "0" \) ]; then
+    echo "need the root privilege to launch tabrmd for the integration test"
     exit 1
 fi
 if [ ! -x "${TABRMD_BIN}" ]; then
@@ -192,27 +204,39 @@ if [ ! -x "${TEST_BIN}" ]; then
     exit 1
 fi
 
-# start an instance of the simulator for the test, have it use a random port
-SIM_LOG_FILE=${TEST_BIN}_simulator.log
-SIM_PID_FILE=${TEST_BIN}_simulator.pid
-SIM_TMP_DIR=$(mktemp --directory --tmpdir=/tmp tpm_server_XXXXXX)
-for i in $(seq 5); do
-    SIM_PORT=$(od -A n -N 2 -t u2 /dev/urandom | awk -v min=1024 -v max=65535 '{print ($1 % (max - min)) + min}')
-    simulator_start ${SIM_BIN} ${SIM_PORT} ${SIM_LOG_FILE} ${SIM_PID_FILE} ${SIM_TMP_DIR}
-    if [ $? -eq 0 ]; then
-        break;
-    else
-        echo "Failed to start simulator on port ${SIM_PORT}, retrying"
-    fi
-done
-# start an instance of the tpm2-abrmd daemon for the test, use port from above
+if [ -n "${SIM_BIN}" ]; then
+    # start an instance of the simulator for the test, have it use a random port
+    SIM_LOG_FILE=${TEST_BIN}_simulator.log
+    SIM_PID_FILE=${TEST_BIN}_simulator.pid
+    SIM_TMP_DIR=$(mktemp --directory --tmpdir=/tmp tpm_server_XXXXXX)
+    for i in $(seq 5); do
+        SIM_PORT=$(od -A n -N 2 -t u2 /dev/urandom | awk -v min=1024 -v max=65535 '{print ($1 % (max - min)) + min}')
+        simulator_start ${SIM_BIN} ${SIM_PORT} ${SIM_LOG_FILE} ${SIM_PID_FILE} ${SIM_TMP_DIR}
+        if [ $? -eq 0 ]; then
+            break;
+        else
+            echo "Failed to start simulator on port ${SIM_PORT}, retrying"
+        fi
+    done
+else
+    SIM_PORT=0
+fi
+
 TABRMD_LOG_FILE=${TEST_BIN}_tabrmd.log
 TABRMD_PID_FILE=${TEST_BIN}_tabrmd.pid
-TABRMD_NAME=com.intel.tss2.Tabrmd${SIM_PORT}
+if [ -n "${SIM_BIN}" ]; then
+    TABRMD_NAME=com.intel.tss2.Tabrmd${SIM_PORT}
+else
+    TABRMD_NAME=com.intel.tss2.Tabrmd
+fi
 tabrmd_start ${TABRMD_BIN} ${SIM_PORT} ${TABRMD_NAME} ${TABRMD_LOG_FILE} ${TABRMD_PID_FILE}
 
 # execute the test script and capture exit code
-env G_MESSAGES_DEBUG=all TABRMD_TEST_BUS_TYPE=session TABRMD_TEST_BUS_NAME="${TABRMD_NAME}" TABRMD_TEST_TCTI_RETRIES=10 $@
+if [ -n "${SIM_BIN}" ]; then
+    env G_MESSAGES_DEBUG=all TABRMD_TEST_BUS_TYPE=session TABRMD_TEST_BUS_NAME="${TABRMD_NAME}" TABRMD_TEST_TCTI_RETRIES=10 $@
+else
+    env G_MESSAGES_DEBUG=all TABRMD_TEST_BUS_NAME="${TABRMD_NAME}" TABRMD_TEST_TCTI_RETRIES=10 $@
+fi
 ret_test=$?
 
 # This sleep is sadly necessary: If we kill the tabrmd w/o sleeping for a
@@ -225,9 +249,11 @@ daemon_stop ${TABRMD_PID_FILE}
 ret_tabrmd=$?
 rm -rf ${TABRMD_PID_FILE}
 
-# teardown simulator, ignore exit code (it's 143?)
-daemon_stop ${SIM_PID_FILE}
-rm -rf ${SIM_TMP_DIR} ${SIM_PID_FILE}
+if [ -n "${SIM_BIN}" ]; then
+    # teardown simulator, ignore exit code (it's 143?)
+    daemon_stop ${SIM_PID_FILE}
+    rm -rf ${SIM_TMP_DIR} ${SIM_PID_FILE}
+fi
 
 # handle exit codes
 if [ $ret_test -ne 0 ]; then

--- a/scripts/warn-user.sh
+++ b/scripts/warn-user.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This is a quick script that parses the log files from 'make check' to
+# extract the number of unit tests in each test binary. It keeps a running
+# total of the tests dumping this count to stdout before exiting.
+
+printf "\033[1;31m"
+echo "***********************************************************"
+echo "                         ATTENTION"
+echo "If this test suite is executed against a TPM it may cause"
+echo "damage to the TPM (NV storage and private key wear out etc)."
+echo
+echo "***********************************************************"
+printf "\033[0m"


### PR DESCRIPTION
This change allows to run the integration tests on a real TPM hardware
via specifying --enable-test-hwtpm.

Signed-off-by: Jia Zhang <qianyue.zj@alibaba-inc.com>