### PR TITLE
Remove --fail-on-loaded-trans command line option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a CHANGELOG](http://keepachangelog.com/)
 ### Added
 - Integration test script and build support to execute integration tests
 against a physical TPM2 device on the build platform.
+### Removed
+- Command line option --fail-on-loaded-trans.
 
 ## 1.2.0 - 2017-12-08
 ### Added

--- a/man/tpm2-abrmd.8.in
+++ b/man/tpm2-abrmd.8.in
@@ -26,11 +26,6 @@ Set an upper bound on the number of concurrent client connections allowed.
 Once this number of client connections is reached new connections will be
 rejected with an error.
 .TP
-\fB\-i,\ \-\-fail-on-loaded-trans\fR
-Cause the daemon to fail on startup when the TPM is found to already have
-transient objects loaded. This is intended as a safe-guard to keep the
-daemon from stomping on the TPM state setup by another process.
-.TP
 \fB\-f,\ \-\-flush-all\fR
 Flush all objects and sessions when daemon is started.
 .TP

--- a/scripts/int-test-funcs.sh
+++ b/scripts/int-test-funcs.sh
@@ -107,7 +107,7 @@ tabrmd_start ()
     local tabrmd_pid_file=$5
 
     local tabrmd_env="G_MESSAGES_DEBUG=all"
-    local tabrmd_opts="--tcti=socket --tcti-socket-port=${tabrmd_port} --session --dbus-name=${tabrmd_name} --fail-on-loaded-trans"
+    local tabrmd_opts="--tcti=socket --tcti-socket-port=${tabrmd_port} --session --dbus-name=${tabrmd_name}"
 
     daemon_start "${tabrmd_bin}" "${tabrmd_opts}" "${tabrmd_log_file}" \
         "${tabrmd_pid_file}" "${tabrmd_env}" "${VALGRIND}" "${LOG_FLAGS}"

--- a/src/tabrmd.c
+++ b/src/tabrmd.c
@@ -125,7 +125,6 @@ init_thread_func (gpointer user_data)
 {
     gmain_data_t *data = (gmain_data_t*)user_data;
     gint ret;
-    uint32_t loaded_trans_objs;
     TSS2_RC rc;
     CommandAttrs *command_attrs;
     ConnectionManager *connection_manager = NULL;
@@ -181,21 +180,6 @@ init_thread_func (gpointer user_data)
     rc = access_broker_init_tpm (data->access_broker);
     if (rc != TSS2_RC_SUCCESS)
         g_error ("failed to initialize AccessBroker: 0x%" PRIx32, rc);
-    /*
-     * Ensure the TPM is in a state in which we can use it w/o stepping all
-     * over someone else.
-     */
-    rc = access_broker_get_trans_object_count (data->access_broker,
-                                               &loaded_trans_objs);
-    if (rc != TSS2_RC_SUCCESS)
-        g_error ("failed to get number of loaded transient objects from "
-                 "access broker 0x%" PRIxPTR " RC: 0x%" PRIx32,
-                 (uintptr_t)data->access_broker,
-                 rc);
-    if ((loaded_trans_objs > 0) && data->options.fail_on_loaded_trans) {
-        tabrmd_critical ("TPM reports 0x%" PRIx32 " loaded transient objects, "
-                         "aborting", loaded_trans_objs);
-    }
     if (data->options.flush_all) {
         access_broker_flush_all_context (data->access_broker);
     }
@@ -310,9 +294,6 @@ parse_opts (gint            argc,
           "The name of desired logger, stdout is default.", "[stdout|syslog]"},
         { "session", 's', 0, G_OPTION_ARG_NONE, &session_bus,
           "Connect to the session bus (system bus is default)." },
-        { "fail-on-loaded-trans", 'i', 0, G_OPTION_ARG_NONE,
-          &options->fail_on_loaded_trans,
-          "Fail initialization if the TPM reports loaded transient objects" },
         { "flush-all", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
           &options->flush_all,
           "Flush all objects and sessions from TPM on startup." },

--- a/src/tabrmd.h
+++ b/src/tabrmd.h
@@ -62,7 +62,6 @@
 typedef struct tabrmd_options {
     GBusType        bus;
     TctiOptions    *tcti_options;
-    gboolean        fail_on_loaded_trans;
     gboolean        flush_all;
     guint           max_connections;
     guint           max_transient_objects;


### PR DESCRIPTION
This option was intended as a safe guard against starting the daemon
while some other process had state stored in the TPM. It was an
incomplete implementation however since it fails to address other loaded
objects like sessions. If this functionality is truly needed then it
should be implemented to fail for any loaded TPM state.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>