### PR TITLE
travis: Install liburiparser-dev.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
       - lcov
       - libglib2.0-dev
       - libdbus-1-dev
+      - liburiparser-dev
       - realpath
   coverity_scan:
     project:


### PR DESCRIPTION
This is required by the upstream tpm2-tss.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>