### PR TITLE
tests: stress test session save/load

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,7 @@ TESTS_INTEGRATION = $(tests_integration)
 endif
 
 XFAIL_TESTS = \
+    test/integration/session-load-from-closed-connection.int \
     test/integration/start-auth-session.int \
     test/integration/tcti-sessions-max.int
 

--- a/test/integration/session-load-from-closed-connection.int.c
+++ b/test/integration/session-load-from-closed-connection.int.c
@@ -48,66 +48,73 @@ int
 main (int argc,
       char *argv[])
 {
-    TSS2_RC rc;
-    TSS2_SYS_CONTEXT *sapi_context;
-    TPMI_SH_AUTH_SESSION  session_handle = 0, session_handle_load = 0;
-    TPMS_CONTEXT          context = { 0, };
-    test_opts_t opts = {
-        .tcti_type      = TCTI_DEFAULT,
-        .device_file    = DEVICE_PATH_DEFAULT,
-        .socket_address = HOSTNAME_DEFAULT,
-        .socket_port    = PORT_DEFAULT,
-        .tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
-        .tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
-        .tcti_retries    = TCTI_RETRIES_DEFAULT,
-    };
 
-    get_test_opts_from_env (&opts);
-    if (sanity_check_test_opts (&opts) != 0)
-        exit (1);
-    g_info ("Creating first SAPI context");
-    sapi_context = sapi_init_from_opts (&opts);
-    if (sapi_context == NULL) {
-        g_error ("Failed to create SAPI context.");
-    }
-    g_info ("Got SAPI context: 0x%" PRIxPTR, (uintptr_t)sapi_context);
-    /* create an auth session */
-    g_info ("Starting unbound, unsaulted auth session");
-    rc = start_auth_session (sapi_context, &session_handle);
-    if (rc != TSS2_RC_SUCCESS) {
-        g_error ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxHANDLE, rc);
-    }
-    g_info ("StartAuthSession for TPM_SE_POLICY success! Session handle: "
-            "0x%08" PRIx32, session_handle);
+	unsigned i;
+	/*
+	 * 5 is where the failures first start, things work at 4.
+	 */
+	for (i=0; i < 5; i++) {
+		TSS2_RC rc;
+		TSS2_SYS_CONTEXT *sapi_context;
+		TPMI_SH_AUTH_SESSION  session_handle = 0, session_handle_load = 0;
+		TPMS_CONTEXT          context = { 0, };
+		test_opts_t opts = {
+			.tcti_type      = TCTI_DEFAULT,
+			.device_file    = DEVICE_PATH_DEFAULT,
+			.socket_address = HOSTNAME_DEFAULT,
+			.socket_port    = PORT_DEFAULT,
+			.tabrmd_bus_type = TCTI_TABRMD_DBUS_TYPE_DEFAULT,
+			.tabrmd_bus_name = TCTI_TABRMD_DBUS_NAME_DEFAULT,
+			.tcti_retries    = TCTI_RETRIES_DEFAULT,
+		};
 
-    /* save context */
-    g_info ("Saving context for session: 0x%" PRIxHANDLE, session_handle);
-    rc = Tss2_Sys_ContextSave (sapi_context, session_handle, &context);
-    if (rc != TSS2_RC_SUCCESS) {
-        g_error ("Tss2_Sys_ContextSave failed: 0x%" PRIxHANDLE, rc);
-    }
-    prettyprint_context (&context);
-    g_info ("Tearding down SAPI connection 0x%" PRIxPTR,
-            (uintptr_t)sapi_context);
-    sapi_teardown_full (sapi_context);
+		get_test_opts_from_env (&opts);
+		if (sanity_check_test_opts (&opts) != 0)
+			exit (1);
+		g_info ("Creating first SAPI context");
+		sapi_context = sapi_init_from_opts (&opts);
+		if (sapi_context == NULL) {
+			g_error ("Failed to create SAPI context.");
+		}
+		g_info ("Got SAPI context: 0x%" PRIxPTR, (uintptr_t)sapi_context);
+		/* create an auth session */
+		g_info ("Starting unbound, unsaulted auth session");
+		rc = start_auth_session (sapi_context, &session_handle);
+		if (rc != TSS2_RC_SUCCESS) {
+			g_error ("Tss2_Sys_StartAuthSession failed: 0x%" PRIxHANDLE, rc);
+		}
+		g_info ("StartAuthSession for TPM_SE_POLICY success! Session handle: "
+				"0x%08" PRIx32, session_handle);
 
-    g_info ("Creating second SAPI context");
-    sapi_context = sapi_init_from_opts (&opts);
-    if (sapi_context == NULL) {
-        g_error ("Failed to create SAPI context.");
-    }
-    g_info ("Got SAPI context: 0x%" PRIxPTR, (uintptr_t)sapi_context);
-    /* reload the session through new connection */
-    g_info ("Loading context for session: 0x%" PRIxHANDLE, session_handle);
-    rc = Tss2_Sys_ContextLoad (sapi_context, &context, &session_handle_load);
-    if (rc != TSS2_RC_SUCCESS) {
-        g_error ("Tss2_Sys_ContextLoad failed: 0x%" PRIxHANDLE, rc);
-    }
-    g_info ("Successfully loaded context for session: 0x%" PRIxHANDLE,
-            session_handle_load);
-    if (session_handle_load != session_handle) {
-        g_error ("session_handle != session_handle_load");
-    }
-    sapi_teardown_full (sapi_context);
+		/* save context */
+		g_info ("Saving context for session: 0x%" PRIxHANDLE, session_handle);
+		rc = Tss2_Sys_ContextSave (sapi_context, session_handle, &context);
+		if (rc != TSS2_RC_SUCCESS) {
+			g_error ("Tss2_Sys_ContextSave failed: 0x%" PRIxHANDLE, rc);
+		}
+		prettyprint_context (&context);
+		g_info ("Tearding down SAPI connection 0x%" PRIxPTR,
+				(uintptr_t)sapi_context);
+		sapi_teardown_full (sapi_context);
+
+		g_info ("Creating second SAPI context");
+		sapi_context = sapi_init_from_opts (&opts);
+		if (sapi_context == NULL) {
+			g_error ("Failed to create SAPI context.");
+		}
+		g_info ("Got SAPI context: 0x%" PRIxPTR, (uintptr_t)sapi_context);
+		/* reload the session through new connection */
+		g_info ("Loading context for session: 0x%" PRIxHANDLE, session_handle);
+		rc = Tss2_Sys_ContextLoad (sapi_context, &context, &session_handle_load);
+		if (rc != TSS2_RC_SUCCESS) {
+			g_error ("Tss2_Sys_ContextLoad failed: 0x%" PRIxHANDLE, rc);
+		}
+		g_info ("Successfully loaded context for session: 0x%" PRIxHANDLE,
+				session_handle_load);
+		if (session_handle_load != session_handle) {
+			g_error ("session_handle != session_handle_load");
+		}
+		sapi_teardown_full (sapi_context);
+	}
     return 0;
 }


### PR DESCRIPTION
At the 5th connection that saves and restores a session handle, abrmd
starts flushing handles and thus they are not available after a
client disconection.

This can be seen in the tools side as well with this simple
stress test:
  - https://github.com/williamcroberts/tpm2.0-tools/blob/session-tools/stress.sh

Changing this test, to try it 5 times causes the same failure, at 4
it works.

Signed-off-by: William Roberts <william.c.roberts@intel.com>