### PR TITLE
build: Include SELinux policy module in the release tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -145,6 +145,10 @@ EXTRA_DIST = \
     scripts/int-simulator-setup.sh \
     scripts/int-hardware-setup.sh \
     scripts/int-test-funcs.sh \
+    selinux/Makefile \
+    selinux/tabrmd.fc \
+    selinux/tabrmd.if \
+    selinux/tabrmd.te \
     AUTHORS \
     CHANGELOG.md \
     CONTRIBUTING.md \


### PR DESCRIPTION
The tarballs generated by the make dist target don't include the SELinux
policy module, so add it to the EXTRA_DIST variable.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>