### PR TITLE
Cleanup tcti init

### DIFF
--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -528,8 +528,8 @@ tss2_tcti_tabrmd_init_config (TSS2_TCTI_CONTEXT *context,
                               size_t            *size,
                               const char        *conf)
 {
-	(void)conf;
-	return tss2_tcti_tabrmd_init(context, size);
+    (void)conf;
+    return tss2_tcti_tabrmd_init(context, size);
 }
 
 /* public info structure */

--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -528,7 +528,11 @@ tss2_tcti_tabrmd_init_config (TSS2_TCTI_CONTEXT *context,
                               size_t            *size,
                               const char        *conf)
 {
-    (void)conf;
+    if (conf != NULL) {
+        g_warning ("%s: received non-NULL conf string though we don't support "
+                   "configuration strings yet.", __func__);
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
     return tss2_tcti_tabrmd_init(context, size);
 }
 


### PR DESCRIPTION
Fixes white space errors. Adds an explicit check for the conf string. Anything but a NULL string will return an error until we have a way to handle the string.