### PR TITLE
tcti-tabrmd: fix NULL conf string

### DIFF
--- a/src/tcti-tabrmd.c
+++ b/src/tcti-tabrmd.c
@@ -632,6 +632,9 @@ tss2_tcti_tabrmd_init_config (TSS2_TCTI_CONTEXT *context,
         TCTI_TABRMD_DBUS_NAME_DEFAULT,
     };
 
+    if (conf == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
     conf_len = strlen (conf);
     if (conf_len > CONF_STRING_MAX) {
         return TSS2_TCTI_RC_BAD_VALUE;


### PR DESCRIPTION
The caller of tss2_tcti_tabrmd_init_config() may pass a NULL conf
string, e.g, launching tpm2_clear without any options, causing a
segment fault.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>