### PR TITLE
[SELinux] Remove gen_require part from tpm-abrmd2 policy.

### DIFF
--- a/selinux/tabrmd.te
+++ b/selinux/tabrmd.te
@@ -15,12 +15,8 @@ dev_rw_tpm(tabrmd_t)
 logging_send_syslog_msg(tabrmd_t)
 
 optional_policy(`
+    dbus_stub()
     dbus_system_domain(tabrmd_t, tabrmd_exec_t)
+    allow system_dbusd_t tabrmd_t:unix_stream_socket rw_stream_socket_perms;
 ')
 
-# This next bit doesn't belong here. It should be exposed through an
-# interface likely from the dbus policy module.
-gen_require(`
-    type system_dbusd_t;
-')
-allow system_dbusd_t tabrmd_t:unix_stream_socket { read write };


### PR DESCRIPTION
Instead of this is useed dbus interface defined in distrubution policy[1] and also upstream reference policy[2]. This allows you to use raw allow rule in policy and there will be no dependency for distribution policy.

[1] https://github.com/fedora-selinux/selinux-policy-contrib/blob/rawhide/dbus.if#L13
[2] https://github.com/TresysTechnology/refpolicy-contrib/blob/master/dbus.if#L13