### PR TITLE
tcti: Migrate TCTIs to use new init interface.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -401,14 +401,14 @@ test_logging_unit_SOURCES = test/logging_unit.c
 if TCTI_DEVICE
 test_tcti_device_unit_CFLAGS   = $(UNIT_AM_CFLAGS)
 test_tcti_device_unit_LDADD    = $(CMOCKA_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(libutil)
-test_tcti_device_unit_LDFLAGS  = -Wl,--wrap=InitDeviceTcti
+test_tcti_device_unit_LDFLAGS  = -Wl,--wrap=Tss2_Tcti_Device_Init
 test_tcti_device_unit_SOURCES  = test/tcti-device_unit.c
 endif
 
 if TCTI_SOCKET
 test_tcti_socket_unit_CFLAGS   = $(UNIT_AM_CFLAGS)
 test_tcti_socket_unit_LDADD    = $(CMOCKA_LIBS) $(GLIB_LIBS) $(TCTI_SOCKET_LIBS) $(GOBJECT_LIBS) $(libutil)
-test_tcti_socket_unit_LDFLAGS  = -Wl,--wrap=InitSocketTcti
+test_tcti_socket_unit_LDFLAGS  = -Wl,--wrap=Tss2_Tcti_Socket_Init
 test_tcti_socket_unit_SOURCES  = test/tcti-socket_unit.c
 endif
 

--- a/src/tcti-device.c
+++ b/src/tcti-device.c
@@ -140,13 +140,9 @@ tcti_device_initialize (TctiDevice *self)
     TSS2_RC        rc       = TSS2_RC_SUCCESS;
     size_t         ctx_size;
 
-    TCTI_DEVICE_CONF config = {
-        .device_path = self->filename,
-    };
-
     if (tcti->tcti_context != NULL)
         goto out;
-    rc = InitDeviceTcti (NULL, &ctx_size, NULL);
+    rc = Tss2_Tcti_Device_Init (NULL, &ctx_size, NULL);
     if (rc != TSS2_RC_SUCCESS) {
         g_warning ("failed to get size for device TCTI contexxt structure: "
                    "0x%x", rc);
@@ -157,7 +153,7 @@ tcti_device_initialize (TctiDevice *self)
         g_warning ("failed to allocate memory");
         goto out;
     }
-    rc = InitDeviceTcti (tcti->tcti_context, &ctx_size, &config);
+    rc = Tss2_Tcti_Device_Init (tcti->tcti_context, &ctx_size, self->filename);
     if (rc != TSS2_RC_SUCCESS) {
         g_warning ("failed to initialize device TCTI context: 0x%x", rc);
         g_free (tcti->tcti_context);

--- a/test/integration/context-util.c
+++ b/test/integration/context-util.c
@@ -43,14 +43,11 @@
 TSS2_TCTI_CONTEXT*
 tcti_device_init (char const *device_path)
 {
-    TCTI_DEVICE_CONF conf = {
-        .device_path =device_path,
-    };
     size_t size;
     TSS2_RC rc;
     TSS2_TCTI_CONTEXT *tcti_ctx;
 
-    rc = InitDeviceTcti (NULL, &size, 0);
+    rc = Tss2_Tcti_Device_Init (NULL, &size, NULL);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr,
                  "Failed to get allocation size for device tcti context: "
@@ -64,7 +61,7 @@ tcti_device_init (char const *device_path)
                  strerror (errno));
         return NULL;
     }
-    rc = InitDeviceTcti (tcti_ctx, &size, &conf);
+    rc = Tss2_Tcti_Socket_Init (tcti_ctx, &size, device_path);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr,
                  "Failed to initialize device TCTI context: 0x%x\n",
@@ -87,15 +84,12 @@ TSS2_TCTI_CONTEXT*
 tcti_socket_init (char const *address,
                   uint16_t    port)
 {
-    TCTI_SOCKET_CONF conf = {
-        .hostname          = address,
-        .port              = port,
-    };
     size_t size;
     TSS2_RC rc;
     TSS2_TCTI_CONTEXT *tcti_ctx;
+    char conf[256] = { 0 } ;
 
-    rc = InitSocketTcti (NULL, &size, &conf, 0);
+    rc = Tss2_Tcti_Socket_Init (NULL, &size, NULL);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Faled to get allocation size for tcti context: "
                  "0x%x\n", rc);
@@ -107,7 +101,8 @@ tcti_socket_init (char const *address,
                  strerror (errno));
         return NULL;
     }
-    rc = InitSocketTcti (tcti_ctx, &size, &conf, 0);
+    snprintf (conf, 256, "tcp://%s:%" PRIu16, address, port);
+    rc = Tss2_Tcti_Socket_Init (tcti_ctx, &size, conf);
     if (rc != TSS2_RC_SUCCESS) {
         fprintf (stderr, "Failed to initialize tcti context: 0x%x\n", rc);
         return NULL;

--- a/test/tcti-device_unit.c
+++ b/test/tcti-device_unit.c
@@ -33,9 +33,9 @@
 #include "tcti-device.h"
 
 TSS2_RC
-__wrap_InitDeviceTcti (TSS2_TCTI_CONTEXT   *tcti_context,
-                       size_t              *size,
-                       TCTI_DEVICE_CONF    *config)
+__wrap_Tss2_Tcti_Device_Init (TSS2_TCTI_CONTEXT   *tcti_context,
+                              size_t              *size,
+                              const char          *conf)
 {
     *size = mock_type (size_t);
     return mock_type (TSS2_RC);
@@ -69,7 +69,7 @@ tcti_device_new_unref_test (void **state)
 }
 
 /**
- * Calling the initialize function causes two calls to InitDeviceTcti. The
+ * Calling the initialize function causes two calls to Tss2_Tcti_Device_Init. The
  * first gets the size of the context structure to allocate, the second
  * does the initialization. Inbetween the function allocates the context.
  */
@@ -79,11 +79,11 @@ tcti_device_initialize_success_unit (void **state)
     TctiDevice *tcti_device = *state;
     TSS2_RC     rc = TSS2_RC_SUCCESS;
 
-    will_return (__wrap_InitDeviceTcti, 512);
-    will_return (__wrap_InitDeviceTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Device_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
 
-    will_return (__wrap_InitDeviceTcti, 512);
-    will_return (__wrap_InitDeviceTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Device_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
 
     rc = tcti_device_initialize (tcti_device);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
@@ -97,17 +97,17 @@ tcti_device_initialize_success_interface_unit (void **state)
     Tcti       *tcti      = *state;
     TSS2_RC     rc = TSS2_RC_SUCCESS;
 
-    will_return (__wrap_InitDeviceTcti, 512);
-    will_return (__wrap_InitDeviceTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Device_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
 
-    will_return (__wrap_InitDeviceTcti, 512);
-    will_return (__wrap_InitDeviceTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Device_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
 
     rc = tcti_initialize (tcti);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 /**
- * Cause first call to InitDeviceTcti in tcti_device_initialize to fail.
+ * Cause first call to Tss2_Tcti_Device_Init in tcti_device_initialize to fail.
  * We should get the RC that we provide in the second will_return sent
  * back to us.
  */
@@ -117,14 +117,14 @@ tcti_device_initialize_fail_on_first_init_unit (void **state)
     TctiDevice *tcti_device = *state;
     TSS2_RC     rc          = TSS2_RC_SUCCESS;
 
-    will_return (__wrap_InitDeviceTcti, 0);
-    will_return (__wrap_InitDeviceTcti, TSS2_TCTI_RC_GENERAL_FAILURE);
+    will_return (__wrap_Tss2_Tcti_Device_Init, 0);
+    will_return (__wrap_Tss2_Tcti_Device_Init, TSS2_TCTI_RC_GENERAL_FAILURE);
 
     rc = tcti_device_initialize (tcti_device);
     assert_int_equal (rc, TSS2_TCTI_RC_GENERAL_FAILURE);
 }
 /**
- * Cause the second call to InitDeviceTcti in the tcti_device_initialize to
+ * Cause the second call to Tss2_Tcti_Device_Init in the tcti_device_initialize to
  * fail. We should get the RC taht we provide in the 4th will_return sent
  * back to us.
  */
@@ -134,11 +134,11 @@ tcti_device_initialize_fail_on_second_init_unit (void **state)
     TctiDevice *tcti_device = *state;
     TSS2_RC     rc = TSS2_RC_SUCCESS;
 
-    will_return (__wrap_InitDeviceTcti, 512);
-    will_return (__wrap_InitDeviceTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Device_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Device_Init, TSS2_RC_SUCCESS);
 
-    will_return (__wrap_InitDeviceTcti, 0);
-    will_return (__wrap_InitDeviceTcti, TSS2_TCTI_RC_GENERAL_FAILURE);
+    will_return (__wrap_Tss2_Tcti_Device_Init, 0);
+    will_return (__wrap_Tss2_Tcti_Device_Init, TSS2_TCTI_RC_GENERAL_FAILURE);
 
     rc = tcti_device_initialize (tcti_device);
     assert_int_equal (rc, TSS2_TCTI_RC_GENERAL_FAILURE);

--- a/test/tcti-socket_unit.c
+++ b/test/tcti-socket_unit.c
@@ -33,7 +33,7 @@
 #include "tcti-socket.h"
 
 TSS2_RC
-__wrap_InitSocketTcti (TSS2_TCTI_CONTEXT *tcti_context,
+__wrap_Tss2_Tcti_Socket_Init (TSS2_TCTI_CONTEXT *tcti_context,
                        size_t *size,
                        TCTI_SOCKET_CONF *config,
                        uint8_t serverSockets)
@@ -70,7 +70,7 @@ tcti_socket_new_unref_test (void **state)
 }
 
 /**
- * Calling the initialize function causes two calls to InitSocketTcti. The
+ * Calling the initialize function causes two calls to Tss2_Tcti_Socket_Init. The
  * first gets the size of the context structure to allocate, the second
  * does the initialization. Inbetween the function allocates the context.
  */
@@ -80,11 +80,11 @@ tcti_socket_initialize_success_unit (void **state)
     TctiSocket *tcti_sock = *state;
     TSS2_RC     rc = TSS2_RC_SUCCESS;
 
-    will_return (__wrap_InitSocketTcti, 512);
-    will_return (__wrap_InitSocketTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, TSS2_RC_SUCCESS);
 
-    will_return (__wrap_InitSocketTcti, 512);
-    will_return (__wrap_InitSocketTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, TSS2_RC_SUCCESS);
 
     rc = tcti_socket_initialize (tcti_sock);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
@@ -98,17 +98,17 @@ tcti_socket_initialize_success_interface_unit (void **state)
     Tcti       *tcti      = *state;
     TSS2_RC     rc = TSS2_RC_SUCCESS;
 
-    will_return (__wrap_InitSocketTcti, 512);
-    will_return (__wrap_InitSocketTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, TSS2_RC_SUCCESS);
 
-    will_return (__wrap_InitSocketTcti, 512);
-    will_return (__wrap_InitSocketTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, TSS2_RC_SUCCESS);
 
     rc = tcti_initialize (tcti);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
 }
 /**
- * Cause first call to InitSocketTcti in tcti_socket_initialize to fail.
+ * Cause first call to Tss2_Tcti_Socket_Init in tcti_socket_initialize to fail.
  * We should get the RC that we provide in the second will_return sent
  * back to us.
  */
@@ -118,14 +118,14 @@ tcti_socket_initialize_fail_on_first_init_unit (void **state)
     TctiSocket *tcti_sock = *state;
     TSS2_RC     rc        = TSS2_RC_SUCCESS;
 
-    will_return (__wrap_InitSocketTcti, 0);
-    will_return (__wrap_InitSocketTcti, TSS2_TCTI_RC_GENERAL_FAILURE);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, 0);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, TSS2_TCTI_RC_GENERAL_FAILURE);
 
     rc = tcti_socket_initialize (tcti_sock);
     assert_int_equal (rc, TSS2_TCTI_RC_GENERAL_FAILURE);
 }
 /**
- * Cause the second call to InitSocketTcti in the tcti_socket_initialize to
+ * Cause the second call to Tss2_Tcti_Socket_Init in the tcti_socket_initialize to
  * fail. We should get the RC taht we provide in the 4th will_return sent
  * back to us.
  */
@@ -135,11 +135,11 @@ tcti_socket_initialize_fail_on_second_init_unit (void **state)
     TctiSocket *tcti_sock = *state;
     TSS2_RC     rc = TSS2_RC_SUCCESS;
 
-    will_return (__wrap_InitSocketTcti, 512);
-    will_return (__wrap_InitSocketTcti, TSS2_RC_SUCCESS);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, 512);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, TSS2_RC_SUCCESS);
 
-    will_return (__wrap_InitSocketTcti, 0);
-    will_return (__wrap_InitSocketTcti, TSS2_TCTI_RC_GENERAL_FAILURE);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, 0);
+    will_return (__wrap_Tss2_Tcti_Socket_Init, TSS2_TCTI_RC_GENERAL_FAILURE);
 
     rc = tcti_socket_initialize (tcti_sock);
     assert_int_equal (rc, TSS2_TCTI_RC_GENERAL_FAILURE);


### PR DESCRIPTION
The old Init*Tcti functions from the upstream TCTIs have been deprecated
and replace with a standard Tss2_Tcti_<name>_Init function.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>